### PR TITLE
fix(ci): audit macOS package by absolute path

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -76,7 +76,8 @@ jobs:
             exit 1
           fi
 
-          pnpm --filter @nxcore/desktop exec asar list "$resources/app.asar" > "$RUNNER_TEMP/asar-files.txt"
+          asar_path="$(cd "$resources" && pwd)/app.asar"
+          pnpm --filter @nxcore/desktop exec asar list "$asar_path" > "$RUNNER_TEMP/asar-files.txt"
           if grep -Eiq "$forbidden" "$RUNNER_TEMP/asar-files.txt"; then
             grep -Ei "$forbidden" "$RUNNER_TEMP/asar-files.txt" >&2
             exit 1

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxcore/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./out/main/index.js",


### PR DESCRIPTION
## Summary- resolve the packaged ASAR by absolute path because `pnpm --filter exec` changes the working directory- bump the desktop version to 0.1.1 for an immutable retry tag## Verification- `pnpm install --frozen-lockfile`- ASAR listing through the filtered desktop command- workflow YAML and release configuration validation