### PR TITLE
修复桌面预发布发布步骤并升级至 0.1.4

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -273,6 +273,12 @@ jobs:
       contents: write
 
     steps:
+      - name: Check out tagged commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxcore/desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "./out/main/index.js",


### PR DESCRIPTION
## 修改内容- 在 `publish` job 发布前检出标签提交，使 `gh release create --verify-tag` 能在有效 Git 仓库中校验标签。- 桌面版本从 `0.1.3` 升级到 `0.1.4`；失败的 `desktop-v0.1.3` 标签保持不动、不复用。## 失败根因`desktop-v0.1.3` 的 macOS 和 Windows 构建、测试、产物审计与上传均成功，但 `publish` job 没有检出仓库。`gh release create --verify-tag` 因此报错：`fatal: not a git repository`。## 本地验证使用 Node 22.23.2、pnpm 11.15.1 完成：- `pnpm install --frozen-lockfile`- `pnpm typecheck`- `pnpm test`（39 个测试文件、218 个测试）- `pnpm build`- Windows x64 NSIS 实际打包- ASAR/资源隐私审计（无 `.env`、测试文件、源码和 source map）- `EverRoom.exe` 与 `win32-x64.node` PE x64 校验- 打包后的 SQLite 原生模块实际加载- NSIS 7-Zip 完整性校验和 SHA256 生成- `git diff --check`本 PR 仅修改 workflow 和 desktop 版本号，不包含测试文件、构建产物或隐私配置。合并后应创建新标签 `desktop-v0.1.4` 重新发版。