### PR TITLE
修复 Agent 任务面板错版并完善飞书合并通知

### DIFF
--- a/.github/workflows/notify-pr-merged.yml
+++ b/.github/workflows/notify-pr-merged.yml
@@ -1,0 +1,48 @@
+name: Notify Feishu when pull request is merged
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Notify Feishu
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        shell: bash
+        run: |
+          if [[ -z "$FEISHU_WEBHOOK_URL" ]]; then
+            echo "::warning::FEISHU_RELEASE_WEBHOOK is not configured; skipping notification."
+            exit 0
+          fi
+
+          message="EverRoom PR 已合并
+          PR：#${PR_NUMBER} ${PR_TITLE}
+          作者：${PR_AUTHOR}
+          合并人：${PR_MERGED_BY}
+          分支：${PR_HEAD} -> ${PR_BASE}
+          链接：${PR_URL}"
+          payload="$(jq -n --arg text "$message" '{msg_type:"text",content:{text:$text}}')"
+          response="$(curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$FEISHU_WEBHOOK_URL")"
+          code="$(jq -r '.code // .StatusCode // -1' <<< "$response")"
+          test "$code" = "0" || {
+            echo "Feishu rejected the notification with code $code" >&2
+            exit 1
+          }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -64,6 +64,10 @@ summary:focus-visible {
   grid-template-columns: var(--nav-width) minmax(0, 1fr) 0;
 }
 
+.app-shell[data-agent-open='true']:has(.agent-office-page) {
+  transition: none;
+}
+
 .app-shell[data-nav-collapsed='true'] {
   grid-template-columns: 0 minmax(0, 1fr) var(--agent-width);
 }


### PR DESCRIPTION
## 修改内容

- 新增 `main` 分支 PR 合并后的飞书群通知工作流。
- 修复从 Agent 状态页点击“发起新任务”时智能区宽度过渡导致的错版问题。
- 智能区现在直接以完整宽度显示，不再裁切输入框、卡片圆角或左侧内容。
- Agent 状态工作区恢复原有固定布局，空间不足时继续使用横向滚动查看完整内容。

## 验证

- Desktop TypeScript 类型检查通过。
- `git diff --check` 通过。
- 已合并最新 `origin/main`。

## 提交范围

本 PR 未包含本地 Nango 调试改动、环境变量、临时输出或其他隐私文件。