### PR TITLE
优化 EverRoom 工作台与连接器体验

### DIFF
--- a/apps/desktop/src/main/gateway/nango-supervisor.ts
+++ b/apps/desktop/src/main/gateway/nango-supervisor.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { cpSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -25,6 +26,16 @@ const CONNECT_UI_PORT = 3009
 const BASE_URL = `http://127.0.0.1:${NANGO_PORT}`
 const STARTUP_TIMEOUT_MS = 120_000
 const SHUTDOWN_TIMEOUT_MS = 5_000
+
+function managedEncryptionKey(): string | undefined {
+  if (process.env.NANGO_ENCRYPTION_KEY || process.env.NANGO_ENCRYPTION_KEY_WRAPPED) {
+    return process.env.NANGO_ENCRYPTION_KEY
+  }
+  const secret = process.env.NXCORE_NANGO_SECRET?.trim()
+  return secret
+    ? createHash('sha256').update('everroom:nango:encryption:v1\0').update(secret).digest('base64')
+    : undefined
+}
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
@@ -85,7 +96,8 @@ export class NangoSupervisor {
     if (!existsSync(join(nangoDirectory, 'package.json'))) {
       throw new Error(`Nango 子模块不存在: ${nangoDirectory}（试试 git submodule update --init）`)
     }
-    if (!existsSync(join(nangoDirectory, 'node_modules', '.bin', 'tsx'))) {
+    const tsxCli = join(nangoDirectory, 'node_modules', 'tsx', 'dist', 'cli.mjs')
+    if (!existsSync(tsxCli)) {
       throw new Error('Nango 依赖未安装:请在 apps/gateway/src/modules/connector 下执行 npm install')
     }
     // 同仓包(shared/utils/...)以 dist 解析,先做一次性全量构建再拉起 server。
@@ -102,16 +114,19 @@ export class NangoSupervisor {
     }
 
     const serverDirectory = join(nangoDirectory, 'packages', 'server')
-    // tsx bin 是带 shebang 的可执行文件,直接 spawn(cwd 在 server 目录,lib/server.ts 相对解析)。
     const child = spawn(
-      join(nangoDirectory, 'node_modules', '.bin', 'tsx'),
-      ['-r', 'dotenv/config', 'lib/server.ts'],
+      process.execPath,
+      [tsxCli, '-r', 'dotenv/config', 'lib/server.ts'],
       {
         cwd: serverDirectory,
         env: {
           ...process.env,
+          ELECTRON_RUN_AS_NODE: '1',
           DOTENV_CONFIG_PATH: join(nangoDirectory, '.env'),
+          FLAG_AUTH_ENABLED: 'false',
           NANGO_EMBEDDED_DB: 'true',
+          NANGO_DB_PORT: '5433',
+          NANGO_ENCRYPTION_KEY: managedEncryptionKey(),
           SERVER_PORT: String(NANGO_PORT),
         },
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -161,9 +176,21 @@ export class NangoSupervisor {
         if (build !== 0) throw new Error(`Connect UI 构建失败（exit=${build}）`)
       }
       const child = spawn(
-        join(nangoDirectory, 'node_modules', '.bin', 'serve'),
-        ['-s', 'dist', '-p', String(CONNECT_UI_PORT), '--no-clipboard'],
-        { cwd: connectUiDirectory, env: process.env, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true },
+        process.execPath,
+        [
+          join(nangoDirectory, 'node_modules', 'serve', 'build', 'main.js'),
+          '-s',
+          'dist',
+          '-p',
+          String(CONNECT_UI_PORT),
+          '--no-clipboard',
+        ],
+        {
+          cwd: connectUiDirectory,
+          env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
+        },
       )
       this.connectUiChild = child
       child.stdin.end()

--- a/apps/desktop/src/renderer/src/components/PageCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/PageCanvas.tsx
@@ -76,6 +76,7 @@ export function PageCanvas({
           onOpenRoomTab={onContextRoomOpenTab}
           onRoomsChange={onContextRoomRoomsChange}
           onShowHome={onContextRoomShowHome}
+          onFocusAgent={onFocusAgent}
         />
       </Suspense>
     )
@@ -98,12 +99,20 @@ export function PageCanvas({
   if (page === 'settings') content = <SettingsPage />
   return (
     <>
-      <div className="reality-page-host" hidden={page !== 'recording'}>
+      <div
+        className="reality-page-host workspace-page-transition"
+        data-page="recording"
+        hidden={page !== 'recording'}
+      >
         <Suspense fallback={<div className="page"><div className="evidence-viewer-state">正在加载现实感知...</div></div>}>
           <RealityPage onOpenSettings={() => onNavigate('settings')} />
         </Suspense>
       </div>
-      {page === 'recording' ? null : content}
+      {page === 'recording' ? null : (
+        <div key={page} className="workspace-page-transition" data-page={page}>
+          {content}
+        </div>
+      )}
     </>
   )
 }

--- a/apps/desktop/src/renderer/src/components/context-room/ContextRoomHomeSkeleton.css
+++ b/apps/desktop/src/renderer/src/components/context-room/ContextRoomHomeSkeleton.css
@@ -3,7 +3,7 @@
   height: 100%;
   min-height: 0;
   overflow: auto;
-  background: #fafafa;
+  background: var(--bg);
   scrollbar-width: none;
 }
 
@@ -15,7 +15,7 @@
   container: context-room-all-skeleton / inline-size;
   height: 100%;
   overflow: hidden;
-  background: #fafafa;
+  background: var(--bg);
 }
 
 .context-room-all-skeleton-layout {

--- a/apps/desktop/src/renderer/src/components/context-room/ContextRoomPage.tsx
+++ b/apps/desktop/src/renderer/src/components/context-room/ContextRoomPage.tsx
@@ -13,6 +13,7 @@ export function ContextRoomPage({
   onOpenRoomTab,
   onRoomsChange,
   onShowHome,
+  onFocusAgent,
 }: {
   activeRoomId: string | null
   focusedDocumentId: string | null
@@ -23,6 +24,7 @@ export function ContextRoomPage({
   onOpenRoomTab: (room: ContextRoomWorkspaceTab) => void
   onRoomsChange: (rooms: ContextRoomWorkspaceTab[]) => void
   onShowHome: () => void
+  onFocusAgent: () => void
 }) {
   return (
     <div className="context-room-operation-shell">
@@ -36,6 +38,7 @@ export function ContextRoomPage({
         onOpenRoomTab={onOpenRoomTab}
         onRoomsChange={onRoomsChange}
         onShowHome={onShowHome}
+        onFocusAgent={onFocusAgent}
       />
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/context-room/ported/ContextRoom.css
+++ b/apps/desktop/src/renderer/src/components/context-room/ported/ContextRoom.css
@@ -15,7 +15,7 @@
 }
 
 .context-room-operation-shell {
-  --cr-canvas: #fff;
+  --cr-canvas: var(--bg);
   --cr-surface: #fff;
   --cr-surface-secondary: #f7f8fa;
   --cr-surface-hover: #f3f4f6;
@@ -32,7 +32,7 @@
 }
 
 .context-room-app {
-  --cr-canvas: #fafafa;
+  --cr-canvas: var(--bg);
   --cr-surface: #ffffff;
   --cr-surface-secondary: #f7f7f6;
   --cr-surface-hover: #f1f2f3;
@@ -87,6 +87,39 @@
   margin: 0 auto;
   flex-direction: column;
   gap: 20px;
+}
+
+.context-room-home-layout > *,
+.context-room-all-layout > *,
+.context-room-object-page > *,
+.context-room-workspace-layout > * {
+  animation: context-room-content-enter 340ms var(--shell-motion-easing) backwards;
+}
+
+.context-room-home-layout > :nth-child(2),
+.context-room-all-layout > :nth-child(2),
+.context-room-object-page > :nth-child(2),
+.context-room-workspace-layout > :nth-child(2) {
+  animation-delay: 45ms;
+}
+
+.context-room-home-layout > :nth-child(3),
+.context-room-all-layout > :nth-child(3),
+.context-room-object-page > :nth-child(3),
+.context-room-workspace-layout > :nth-child(3) {
+  animation-delay: 90ms;
+}
+
+.context-room-home-layout > :nth-child(n + 4),
+.context-room-all-layout > :nth-child(n + 4),
+.context-room-object-page > :nth-child(n + 4),
+.context-room-workspace-layout > :nth-child(n + 4) {
+  animation-delay: 135ms;
+}
+
+@keyframes context-room-content-enter {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .context-room-home-section {
@@ -4178,7 +4211,7 @@
 }
 
 .context-room-app {
-  --cr-canvas: #fff;
+  --cr-canvas: var(--bg);
   --cr-surface: #fff;
   --cr-surface-secondary: #f7f8fa;
   --cr-surface-sunken: #f3f4f6;
@@ -9330,6 +9363,10 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--cr-border);
+  border-radius: 7px;
+  background: var(--cr-surface);
 }
 
 .context-room-knowledge-panel .context-room-my-title {
@@ -9355,10 +9392,57 @@
   height: 20px;
 }
 
+.context-room-knowledge-empty h3 {
+  margin: 0;
+  color: var(--cr-text);
+  font-size: 14px;
+  font-weight: 600;
+}
+
 .context-room-knowledge-empty p {
   margin: 0;
   max-width: 420px;
   font-size: 12px;
+}
+
+.context-room-knowledge-empty-cta {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 13px 4px 5px;
+  border: 1px solid color-mix(in srgb, var(--cr-blue) 24%, var(--cr-border));
+  border-radius: 7px;
+  background: var(--cr-blue-soft);
+  color: var(--cr-blue);
+  font-size: 12px;
+  font-weight: 600;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.context-room-knowledge-empty-cta:hover {
+  border-color: var(--cr-blue);
+  background: color-mix(in srgb, var(--cr-blue) 15%, var(--cr-surface));
+  box-shadow: 0 2px 5px color-mix(in srgb, var(--cr-blue) 16%, transparent);
+}
+
+.context-room-knowledge-empty-cta:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--cr-blue) 32%, transparent);
+  outline-offset: 2px;
+}
+
+.context-room-knowledge-empty-cta-icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--cr-surface);
+}
+
+.context-room-knowledge-empty-cta-icon svg {
+  width: 15px;
+  height: 15px;
 }
 
 .context-room-knowledge-list {
@@ -9632,6 +9716,62 @@
   border: 1px solid var(--cr-border);
   border-radius: 10px;
   background: var(--cr-surface-secondary);
+}
+
+.context-room-knowledge-history {
+  border: 1px solid var(--cr-border);
+  border-radius: 10px;
+  background: var(--cr-surface-secondary);
+}
+
+.context-room-knowledge-history > summary {
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 14px;
+  color: var(--cr-tertiary);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  list-style: none;
+}
+
+.context-room-knowledge-history > summary::-webkit-details-marker {
+  display: none;
+}
+
+.context-room-knowledge-history > summary small {
+  min-width: 18px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: var(--cr-surface);
+  color: var(--cr-muted);
+  font-size: 10px;
+  font-weight: 500;
+  text-align: center;
+}
+
+.context-room-knowledge-history > summary svg {
+  width: 14px;
+  height: 14px;
+  margin-left: auto;
+  transition: transform 0.15s ease;
+}
+
+.context-room-knowledge-history[open] > summary svg {
+  transform: rotate(180deg);
+}
+
+.context-room-knowledge-history-content {
+  padding: 0 10px 10px;
+}
+
+.context-room-knowledge-history .context-room-knowledge-recent {
+  padding: 0 4px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .context-room-knowledge-recent h3 {

--- a/apps/desktop/src/renderer/src/components/context-room/ported/PortedContextRoom.tsx
+++ b/apps/desktop/src/renderer/src/components/context-room/ported/PortedContextRoom.tsx
@@ -47,6 +47,7 @@ export function PortedContextRoom({
   onOpenRoomTab,
   onRoomsChange,
   onShowHome,
+  onFocusAgent,
 }: {
   activeRoomId: string | null
   focusedDocumentId: string | null
@@ -57,6 +58,7 @@ export function PortedContextRoom({
   onOpenRoomTab: (room: ContextRoomWorkspaceTab) => void
   onRoomsChange: (rooms: ContextRoomWorkspaceTab[]) => void
   onShowHome: () => void
+  onFocusAgent: () => void
 }) {
   const { state, setState } = useContextRoomState()
   const handledHomeRequest = useRef(homeRequest)
@@ -274,6 +276,7 @@ export function PortedContextRoom({
       }}
       onOpenDetail={openRoom}
       onShowAll={() => setHomeView('all')}
+      onFocusAgent={onFocusAgent}
     />
   )
 }

--- a/apps/desktop/src/renderer/src/components/context-room/ported/components/HomeView.tsx
+++ b/apps/desktop/src/renderer/src/components/context-room/ported/components/HomeView.tsx
@@ -127,6 +127,7 @@ export function HomeView({
   onOpenRecommendationSource,
   onOpenDetail,
   onShowAll,
+  onFocusAgent,
 }: {
   rooms: ContextRoomRecord[];
   deletedRooms: ContextRoomRecord[];
@@ -137,6 +138,7 @@ export function HomeView({
   onOpenRecommendationSource: (source: RoomRecommendationSource) => void;
   onOpenDetail: (roomId: string) => void;
   onShowAll: () => void;
+  onFocusAgent: () => void;
 }) {
   const [query, setQuery] = useState('');
   const [recommendation, setRecommendation] = useState<RoomRecommendation | null>(null);
@@ -227,7 +229,7 @@ export function HomeView({
             ) : null}
           </section>
 
-          <KnowledgePendingPanel />
+          <KnowledgePendingPanel onFocusAgent={onFocusAgent} />
 
           <RoomGraph rooms={rooms} onOpen={onOpenDetail} />
         </div>

--- a/apps/desktop/src/renderer/src/components/context-room/ported/components/KnowledgePendingPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/context-room/ported/components/KnowledgePendingPanel.tsx
@@ -1,4 +1,4 @@
-import { Inbox, Link2, RefreshCw, Sparkles, Undo2, Upload } from 'lucide-react';
+import { ChevronDown, Inbox, Link2, MessageCircle, RefreshCw, Sparkles, Undo2, Upload } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { showToast } from '@/state/toast';
@@ -31,7 +31,7 @@ const RECOMMEND_LIMIT = 3;
  * 推荐 Room 面板（entity-room-plan 推荐确认制）：达阈值实体进 ready
  * 推荐池，用户确认后才创建 Room；未识别栏/最近归类保持人工治理入口。
  */
-export function KnowledgePendingPanel() {
+export function KnowledgePendingPanel({ onFocusAgent }: { onFocusAgent: () => void }) {
   const [recommended, setRecommended] = useState<KnowledgeEntityDto[]>([]);
   const [attachPool, setAttachPool] = useState<KnowledgeEntityDto[]>([]);
   const [unmatched, setUnmatched] = useState<KnowledgeUnmatchedItemDto[]>([]);
@@ -193,8 +193,6 @@ export function KnowledgePendingPanel() {
 
   if (!loaded) return null;
 
-  const empty = recommended.length === 0 && unmatched.length === 0 && recent.length === 0;
-
   return (
     <section className="context-room-knowledge-panel" data-testid="context-room-knowledge-pending">
       <div className="context-room-my-title">
@@ -225,14 +223,21 @@ export function KnowledgePendingPanel() {
         </div>
       </div>
 
-      {empty ? (
+      {recommended.length === 0 ? (
         <div className="context-room-knowledge-empty">
           <Inbox aria-hidden="true" />
-          <p>暂无推荐 Room。上传资料后系统会自动抽取实体并累积证据，达到阈值即在此推荐。</p>
+          <h3>正在理解资料中</h3>
+          <p>你也可以告诉 Agent 想创建什么 Room。</p>
+          <button type="button" className="context-room-knowledge-empty-cta" onClick={onFocusAgent}>
+            <span className="context-room-knowledge-empty-cta-icon">
+              <MessageCircle aria-hidden="true" />
+            </span>
+            <span>和 Agent 说</span>
+          </button>
         </div>
       ) : (
         <div className="context-room-knowledge-list">
-          {recommended.length > 0 ? <h3 className="context-room-knowledge-group">推荐（按证据分排序，前 3）</h3> : null}
+          <h3 className="context-room-knowledge-group">推荐（按证据分排序，前 3）</h3>
           {recommended.map((entity) => {
             const scoreRatio = Math.min(1, entity.evidenceScore / entity.promoteScore);
             return (
@@ -266,8 +271,12 @@ export function KnowledgePendingPanel() {
               </article>
             );
           })}
+        </div>
+      )}
 
-          {unmatched.length > 0 ? <h3 className="context-room-knowledge-group">未识别资料（等待挂载）</h3> : null}
+      {unmatched.length > 0 ? (
+        <div className="context-room-knowledge-list">
+          <h3 className="context-room-knowledge-group">未识别资料（等待挂载）</h3>
           {unmatched.map((item) => {
             const selection = attachSelection[item.decisionId] ?? '';
             const draft = attachDrafts[item.decisionId];
@@ -337,10 +346,18 @@ export function KnowledgePendingPanel() {
               </article>
             );
           })}
+        </div>
+      ) : null}
 
-          {recent.length > 0 ? (
+      {recent.length > 0 ? (
+        <details className="context-room-knowledge-history">
+          <summary>
+            <span>历史记录</span>
+            <small>{recent.length}</small>
+            <ChevronDown aria-hidden="true" />
+          </summary>
+          <div className="context-room-knowledge-history-content">
             <div className="context-room-knowledge-recent">
-              <h3>最近归类（可撤销）</h3>
               {recent.map((item) => (
                 <div key={item.decisionId} className="context-room-knowledge-recent-row">
                   <span className="context-room-knowledge-recent-title">{item.title}</span>
@@ -358,9 +375,9 @@ export function KnowledgePendingPanel() {
                 </div>
               ))}
             </div>
-          ) : null}
-        </div>
-      )}
+          </div>
+        </details>
+      ) : null}
     </section>
   );
 }

--- a/apps/desktop/src/renderer/src/components/diary/DiaryPage.css
+++ b/apps/desktop/src/renderer/src/components/diary/DiaryPage.css
@@ -4,7 +4,7 @@
   --diary-line: color-mix(in srgb, var(--border) 82%, transparent);
   overflow-y: auto;
   padding: 0 0 96px;
-  background: var(--surface);
+  background: var(--bg);
   color: var(--text);
 }
 

--- a/apps/desktop/src/renderer/src/components/diary/DiaryPageSkeleton.css
+++ b/apps/desktop/src/renderer/src/components/diary/DiaryPageSkeleton.css
@@ -3,7 +3,7 @@
   --diary-skeleton-soft: color-mix(in srgb, var(--border) 34%, var(--surface));
   overflow: hidden auto;
   padding: 0 0 96px;
-  background: var(--surface);
+  background: var(--bg);
 }
 
 .diary-skeleton-status {

--- a/apps/desktop/src/renderer/src/components/pages/AgentStatusPage.css
+++ b/apps/desktop/src/renderer/src/components/pages/AgentStatusPage.css
@@ -114,7 +114,7 @@
 .execution-desk svg { position: absolute; top: -35px; left: 36px; width: 38px; height: 28px; padding: 5px; border: 3px solid #39443f; background: #bed8d2; color: #62736d; }
 .execution-desk i { position: absolute; bottom: -10px; left: 8px; width: 3px; height: 10px; background: #7e8783; } .execution-desk i + i { left: auto; right: 8px; }
 
-.horse-agent { --horse-x: 48%; --horse-y: 58%; position: absolute; z-index: 20; left: var(--horse-x); top: var(--horse-y); width: 104px; transform: translate(-50%, -50%); transition: left .9s cubic-bezier(.22,1,.36,1), top .9s cubic-bezier(.22,1,.36,1); pointer-events: none; filter: drop-shadow(0 6px 5px rgba(26,37,33,.15)); }
+.horse-agent { --horse-cycle: 1.25s; --horse-x: 48%; --horse-y: 58%; position: absolute; z-index: 20; left: var(--horse-x); top: var(--horse-y); width: 104px; transform: translate(-50%, -50%); transition: left .9s cubic-bezier(.22,1,.36,1), top .9s cubic-bezier(.22,1,.36,1); pointer-events: none; filter: drop-shadow(0 6px 5px rgba(26,37,33,.15)); }
 .office-scene[data-horse-zone='desk'] .horse-agent { --horse-x: 43%; --horse-y: 77%; }
 .office-scene[data-horse-zone='coffee'] .horse-agent { --horse-x: 82%; --horse-y: 31%; }
 .office-scene[data-horse-zone='kitchen'] .horse-agent { --horse-x: 22%; --horse-y: 31%; }
@@ -122,20 +122,22 @@
 .office-scene[data-horse-zone='restroom'] .horse-agent { --horse-x: 19%; --horse-y: 76%; }
 .horse-agent > span { position: absolute; bottom: calc(100% + 3px); left: 50%; padding: 4px 7px; border: 1px solid #d6dcda; border-radius: 5px; background: rgba(255,255,255,.94); color: #405048; font-size: 7px; font-weight: 700; white-space: nowrap; transform: translateX(-50%); }
 .horse-agent svg { width: 104px; height: 88px; overflow: visible; }
-.horse-body { transform-origin: 65px 91px; animation: horse-hop 1.25s cubic-bezier(.34,.01,.38,1) infinite; }
-.horse-shadow { fill: rgba(33,43,38,.16); animation: horse-shadow 1.25s ease-in-out infinite; }
+.horse-body { transform-box: view-box; transform-origin: 65px 91px; animation: horse-hop var(--horse-cycle) cubic-bezier(.34,.01,.38,1) infinite; }
+.horse-shadow { fill: rgba(33,43,38,.16); animation: horse-shadow var(--horse-cycle) ease-in-out infinite; }
 .horse-fill, .horse-neck, .horse-head { fill: #202a27; stroke: #111816; stroke-width: 2; }
 .horse-tail, .horse-ear, .horse-mane, .horse-muzzle { fill: none; stroke: #17201d; stroke-width: 7; stroke-linecap: round; stroke-linejoin: round; }
 .horse-eye { fill: #fff; }
-.horse-leg { fill: none; stroke: #18211e; stroke-width: 8; stroke-linecap: round; transform-origin: top; }
+.horse-leg { fill: none; stroke: #18211e; stroke-width: 8; stroke-linecap: round; transform-box: view-box; }
 .horse-saddle { fill: #318f73; stroke: #176a52; stroke-width: 2; }
 .horse-badge { fill: none; stroke: #fff; stroke-width: 3; stroke-linecap: round; }
-.horse-leg-a, .horse-leg-c { animation: horse-leg-a 1.25s ease-in-out infinite; }
-.horse-leg-b, .horse-leg-d { animation: horse-leg-b 1.25s ease-in-out infinite; }
+.horse-leg-a { transform-origin: 38px 72px; animation: horse-leg-a var(--horse-cycle) ease-in-out infinite; }
+.horse-leg-b { transform-origin: 51px 77px; animation: horse-leg-b var(--horse-cycle) ease-in-out infinite; }
+.horse-leg-c { transform-origin: 75px 77px; animation: horse-leg-a var(--horse-cycle) ease-in-out infinite; }
+.horse-leg-d { transform-origin: 86px 71px; animation: horse-leg-b var(--horse-cycle) ease-in-out infinite; }
 @keyframes horse-hop { 0%,100% { transform: translateY(0) rotate(-1deg); } 45% { transform: translateY(-18px) rotate(3deg); } 65% { transform: translateY(-13px) rotate(1deg); } }
 @keyframes horse-shadow { 0%,100% { transform: scaleX(1); opacity: .18; } 45% { transform: scaleX(.68); opacity: .08; } }
 @keyframes horse-leg-a { 50% { transform: rotate(17deg); } } @keyframes horse-leg-b { 50% { transform: rotate(-17deg); } }
-.office-scene[data-running='true'] .horse-body { animation-duration: .72s; }
+.office-scene[data-running='true'] .horse-agent { --horse-cycle: .72s; }
 .office-path { position: absolute; z-index: 1; inset: 0; pointer-events: none; }
 .office-path i { position: absolute; width: 4px; height: 4px; border-radius: 50%; background: #c9cfcb; box-shadow: 12px 3px #c9cfcb, 24px 0 #c9cfcb; opacity: .65; }
 .office-path i:nth-child(1) { top: 46%; left: 20%; } .office-path i:nth-child(2) { top: 47%; right: 18%; transform: rotate(20deg); } .office-path i:nth-child(3) { bottom: 19%; left: 24%; transform: rotate(70deg); } .office-path i:nth-child(4) { bottom: 18%; right: 22%; transform: rotate(-70deg); } .office-path i:nth-child(5) { top: 48%; left: 48%; transform: rotate(90deg); }

--- a/apps/desktop/src/renderer/src/components/pages/AgentStatusPage.tsx
+++ b/apps/desktop/src/renderer/src/components/pages/AgentStatusPage.tsx
@@ -57,6 +57,10 @@ function HorseMascot() {
     <svg viewBox="0 0 132 112" role="img" aria-label="执行 Agent 马形角色">
       <ellipse className="horse-shadow" cx="67" cy="102" rx="39" ry="7" />
       <g className="horse-body">
+        <path className="horse-leg horse-leg-a" d="M38 72c-2 10-4 18-3 27" />
+        <path className="horse-leg horse-leg-b" d="M51 77c4 8 7 16 9 23" />
+        <path className="horse-leg horse-leg-c" d="M75 77c0 9 0 17-1 24" />
+        <path className="horse-leg horse-leg-d" d="M86 71c5 8 9 17 12 25" />
         <path className="horse-tail" d="M32 52C16 48 18 34 7 29c17-2 25 8 31 18" />
         <ellipse className="horse-fill" cx="60" cy="57" rx="34" ry="23" />
         <path className="horse-neck" d="M77 49c5-14 5-30 17-39 10 3 18 13 17 25L91 61Z" />
@@ -65,10 +69,6 @@ function HorseMascot() {
         <path className="horse-ear" d="m94 12-2-10 8 8m8 1 6-8v12" />
         <path className="horse-mane" d="M91 16c-7 8-8 19-8 29" />
         <circle className="horse-eye" cx="109" cy="16" r="2.5" />
-        <path className="horse-leg horse-leg-a" d="M38 72l-5 27" />
-        <path className="horse-leg horse-leg-b" d="M51 77l9 23" />
-        <path className="horse-leg horse-leg-c" d="M75 77l-1 24" />
-        <path className="horse-leg horse-leg-d" d="M86 71l12 25" />
         <path className="horse-saddle" d="M42 36h35l8 21H39Z" />
         <path className="horse-badge" d="M59 41v12m-6-6h12" />
       </g>

--- a/apps/desktop/src/renderer/src/components/pages/SettingsPage.css
+++ b/apps/desktop/src/renderer/src/components/pages/SettingsPage.css
@@ -1,5 +1,5 @@
 .cloud-account-section {
-  width: min(720px, 100%);
+  width: min(1200px, 100%);
   margin-bottom: 18px;
   overflow: hidden;
   border: 1px solid var(--border);
@@ -7,7 +7,7 @@
   background: var(--surface);
 }
 
-.reality-settings-section { width: min(720px, 100%); margin-bottom: 18px; overflow: hidden; border: 1px solid var(--border); border-radius: 7px; background: var(--surface); }
+.reality-settings-section { width: min(1200px, 100%); margin-bottom: 18px; overflow: hidden; border: 1px solid var(--border); border-radius: 7px; background: var(--surface); }
 .reality-settings-section > header { display: grid; grid-template-columns: 38px minmax(0, 1fr); align-items: center; gap: 12px; padding: 16px 18px; border-bottom: 1px solid var(--border); background: var(--surface-alt); }
 .reality-settings-section > header > span { display: grid; width: 38px; height: 38px; place-items: center; border: 1px solid var(--border); border-radius: 7px; background: var(--surface); color: var(--accent); }
 .reality-settings-section > header svg { width: 18px; height: 18px; }
@@ -509,7 +509,7 @@
     border-bottom: 0;
   }
 }
-.developer-settings-section { display: flex; width: min(720px, 100%); align-items: center; gap: 16px; margin-top: 18px; padding: 14px 16px; border: 1px dashed var(--border-strong); border-radius: 6px; background: var(--surface-alt); }
+.developer-settings-section { display: flex; width: min(1200px, 100%); align-items: center; gap: 16px; margin-top: 18px; padding: 14px 16px; border: 1px dashed var(--border-strong); border-radius: 6px; background: var(--surface-alt); }
 .developer-settings-section header { display: flex; min-width: 0; flex: 1; align-items: center; gap: 10px; }
 .developer-settings-section header > span { display: grid; width: 34px; height: 34px; flex: 0 0 34px; place-items: center; border: 1px solid var(--border); border-radius: 5px; background: var(--surface); color: var(--muted); }
 .developer-settings-section header svg, .developer-settings-section button svg { width: 15px; height: 15px; }
@@ -518,16 +518,22 @@
 
 
 /* MCP 服务器管理 */
-.mcp-settings-section header {
-  align-items: flex-start;
+.mcp-settings-section > header {
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.mcp-settings-section > header .secondary-button {
+  white-space: nowrap;
 }
 
 .mcp-server-form {
   display: grid;
   gap: 12px;
+  margin: 14px 16px 0;
   padding: 14px 16px;
   border: 1px solid var(--border, #e5e3dd);
-  border-radius: 12px;
+  border-radius: 7px;
   background: var(--surface, #faf9f6);
 }
 
@@ -558,16 +564,18 @@
 .mcp-server-list {
   display: grid;
   gap: 8px;
+  margin: 14px 16px;
 }
 
 .mcp-server-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 10px 14px;
   border: 1px solid var(--border, #e5e3dd);
-  border-radius: 10px;
+  border-radius: 7px;
   background: #fff;
 }
 
@@ -584,7 +592,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 420px;
   color: var(--muted, #6f6a60);
 }
 
@@ -605,13 +612,39 @@
   gap: 4px;
   padding: 18px 16px;
   border: 1px dashed var(--border, #e5e3dd);
-  border-radius: 10px;
+  margin: 14px 16px;
+  border-radius: 7px;
   color: var(--muted, #6f6a60);
   text-align: center;
 }
 
 .mcp-config-path {
   display: block;
+  margin: 0 16px 14px;
+  padding: 8px 10px;
+  border-radius: 5px;
+  background: var(--surface-alt, #faf9f6);
   color: var(--muted, #6f6a60);
-  word-break: break-all;
+  font-size: 10px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 720px) {
+  .mcp-settings-section > header {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .mcp-settings-section > header .secondary-button {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .mcp-server-row {
+    grid-template-columns: 1fr;
+  }
+
+  .mcp-server-actions {
+    flex-wrap: wrap;
+  }
 }

--- a/apps/desktop/src/renderer/src/components/pages/WikiPage.css
+++ b/apps/desktop/src/renderer/src/components/pages/WikiPage.css
@@ -179,6 +179,68 @@
   background: var(--surface);
 }
 
+/* Keep the top-level Wiki usable before the lazy Context Room stylesheet loads. */
+.wiki-tree-pane .context-room-wiki-tree,
+.wiki-tree-pane .context-room-wiki-tree-children {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.wiki-tree-pane .context-room-wiki-tree-children {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.wiki-tree-pane .context-room-wiki-tree-node {
+  display: flex;
+  width: 100%;
+  min-height: 32px;
+  align-items: center;
+  gap: 6px;
+  padding-right: 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  text-align: left;
+}
+
+.wiki-tree-pane .context-room-wiki-tree-node:hover {
+  background: var(--hover);
+}
+
+.wiki-tree-pane .context-room-wiki-tree-node[data-selected='true'] {
+  background: var(--accent-soft, rgba(64, 140, 240, 0.12));
+  font-weight: 600;
+}
+
+.wiki-tree-pane .context-room-wiki-tree-node[data-directory='true'] {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.wiki-tree-pane .context-room-wiki-tree-node svg {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+}
+
+.wiki-tree-pane .context-room-wiki-tree-caret {
+  width: 13px !important;
+  height: 13px !important;
+  color: var(--muted);
+}
+
+.wiki-tree-pane .context-room-wiki-tree-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .wiki-tree-pane ul {
   margin: 0;
   padding: 0;

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2389,6 +2389,7 @@ summary:focus-visible {
   .app-shell,
   .app-shell[data-agent-open='false'] {
     grid-template-columns: 0 minmax(0, 1fr) 0;
+    transition: none;
   }
 
   .agent-panel {
@@ -2396,6 +2397,7 @@ summary:focus-visible {
     z-index: 70;
     inset: var(--topbar-height) 0 0 auto;
     width: min(var(--agent-width), 92vw);
+    background: #fff;
     box-shadow: -12px 0 32px rgba(25, 25, 20, 0.12);
   }
 }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -771,6 +771,49 @@ summary:focus-visible {
   height: 100%;
 }
 
+.workspace-page-transition {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg);
+  animation: workspace-page-enter var(--shell-motion-duration) var(--shell-motion-easing) backwards;
+}
+
+.workspace-page-transition:not([data-page='diary']) > .page > *,
+.workspace-page-transition .workspace-home-inner > *,
+.reality-page-host:not([hidden]) .reality-page > * {
+  animation: workspace-content-enter 340ms var(--shell-motion-easing) backwards;
+}
+
+.workspace-page-transition:not([data-page='diary']) > .page > :nth-child(2),
+.workspace-page-transition .workspace-home-inner > :nth-child(2),
+.reality-page-host:not([hidden]) .reality-page > :nth-child(2) {
+  animation-delay: 45ms;
+}
+
+.workspace-page-transition:not([data-page='diary']) > .page > :nth-child(3),
+.workspace-page-transition .workspace-home-inner > :nth-child(3),
+.reality-page-host:not([hidden]) .reality-page > :nth-child(3) {
+  animation-delay: 90ms;
+}
+
+.workspace-page-transition:not([data-page='diary']) > .page > :nth-child(n + 4),
+.workspace-page-transition .workspace-home-inner > :nth-child(n + 4),
+.reality-page-host:not([hidden]) .reality-page > :nth-child(n + 4) {
+  animation-delay: 135ms;
+}
+
+@keyframes workspace-page-enter {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes workspace-content-enter {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 .page {
   position: relative;
   width: 100%;

--- a/apps/desktop/tests/knowledge-pending-panel.test.tsx
+++ b/apps/desktop/tests/knowledge-pending-panel.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/state/toast', () => ({ showToast: vi.fn() }))
+
+import { KnowledgePendingPanel } from '../src/renderer/src/components/context-room/ported/components/KnowledgePendingPanel'
+
+function installKnowledge({ recommended = [], recent = [] }: { recommended?: unknown[]; recent?: unknown[] }) {
+  vi.stubGlobal('window', {
+    addEventListener: vi.fn(),
+    clearInterval: vi.fn(),
+    nxcore: {
+      knowledge: {
+        listEntities: vi.fn((status: string) => Promise.resolve({ items: status === 'ready' ? recommended : [] })),
+        listRecentDecisions: vi.fn(() => Promise.resolve({ items: recent })),
+        listUnmatched: vi.fn(() => Promise.resolve({ items: [] })),
+      },
+    },
+    removeEventListener: vi.fn(),
+    setInterval: vi.fn(() => 1),
+  })
+}
+
+describe('KnowledgePendingPanel', () => {
+  let renderer: TestRenderer.ReactTestRenderer | null = null
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps recent classifications in collapsed history while the recommendation empty state opens Agent', async () => {
+    installKnowledge({
+      recent: [{
+        decisionId: 'decision-1',
+        title: '已归类资料',
+        roomId: 'room-1',
+        roomTitle: '产品 Room',
+      }],
+    })
+    const onFocusAgent = vi.fn()
+
+    await act(async () => {
+      renderer = TestRenderer.create(<KnowledgePendingPanel onFocusAgent={onFocusAgent} />)
+      await Promise.resolve()
+    })
+
+    expect(renderer!.root.findByType('h3').children).toContain('正在理解资料中')
+    const history = renderer!.root.findByType('details')
+    expect(history.props.open).toBeUndefined()
+    expect(history.findByType('summary').findByType('span').children).toContain('历史记录')
+
+    const agentButton = renderer!.root.findAllByType('button')
+      .find((button) => button.props.className === 'context-room-knowledge-empty-cta')
+    expect(agentButton).toBeDefined()
+    act(() => agentButton!.props.onClick())
+    expect(onFocusAgent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/gateway/src/modules/connectors/nango-bootstrap.ts
+++ b/apps/gateway/src/modules/connectors/nango-bootstrap.ts
@@ -56,16 +56,27 @@ async function bootstrapApiKey(baseUrl: string): Promise<string | null> {
   }
 }
 
-async function ensureIntegration(
+export async function ensureIntegration(
   dashboard: AxiosInstance,
   providerConfigKey: string,
   provider: string,
   clientId: string,
   clientSecret: string,
+  scopes?: string,
 ): Promise<void> {
   try {
     const existing = await dashboard.get(`/api/v1/integrations/${encodeURIComponent(providerConfigKey)}`, { params: { env: "dev" }, validateStatus: () => true });
-    if (existing.status === 200) return;
+    if (existing.status === 200) {
+      if (scopes && existing.data?.data?.integration?.oauth_scopes !== scopes) {
+        await dashboard.patch(
+          `/api/v1/integrations/${encodeURIComponent(providerConfigKey)}`,
+          { authType: "OAUTH2", scopes },
+          { params: { env: "dev" } },
+        );
+        console.info(`[nango-bootstrap] Updated scopes for integration ${providerConfigKey}`);
+      }
+      return;
+    }
     if (existing.status !== 404) {
       console.warn(`[nango-bootstrap] 查询 integration ${providerConfigKey} 失败(HTTP ${existing.status})`);
       return;
@@ -74,7 +85,7 @@ async function ensureIntegration(
       provider,
       integrationId: providerConfigKey,
       useSharedCredentials: false,
-      auth: { authType: "OAUTH2", clientId, clientSecret },
+      auth: { authType: "OAUTH2", clientId, clientSecret, ...(scopes ? { scopes } : {}) },
     }, { params: { env: "dev" } });
     console.info(`[nango-bootstrap] 已创建 integration ${providerConfigKey} (provider=${provider})`);
   } catch (error) {
@@ -101,8 +112,13 @@ export async function bootstrapNango(config: ConnectorConfig): Promise<string> {
   // 无鉴权 dashboard API(创建 integration 需要);外部带鉴权的 Nango 会 401,仅记录。
   const dashboard = axios.create({ baseURL: baseUrl.replace(/\/$/, ""), timeout: 15_000 });
   if (config.googleClientId && config.googleClientSecret) {
-    for (const key of [config.gmailConfigKey, config.googleCalendarConfigKey, config.googleDocsConfigKey]) {
-      if (key) await ensureIntegration(dashboard, key, key, config.googleClientId, config.googleClientSecret);
+    const integrations = [
+      [config.gmailConfigKey, "google-mail", "openid,email,profile,https://www.googleapis.com/auth/gmail.readonly"],
+      [config.googleCalendarConfigKey, "google-calendar", "openid,email,profile,https://www.googleapis.com/auth/calendar.readonly"],
+      [config.googleDocsConfigKey, "google-drive", "openid,email,profile,https://www.googleapis.com/auth/drive.readonly"],
+    ] as const;
+    for (const [key, provider, scopes] of integrations) {
+      if (key) await ensureIntegration(dashboard, key, provider, config.googleClientId, config.googleClientSecret, scopes);
     }
   }
   if (config.notionClientId && config.notionClientSecret) {

--- a/apps/gateway/tests/nango-bootstrap.test.ts
+++ b/apps/gateway/tests/nango-bootstrap.test.ts
@@ -1,0 +1,29 @@
+import type { AxiosInstance } from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import { ensureIntegration } from "../src/modules/connectors/nango-bootstrap.js";
+
+describe("Nango integration bootstrap", () => {
+  it("creates and repairs OAuth scopes without redundant updates", async () => {
+    const scopes = "openid,email,profile,https://www.googleapis.com/auth/gmail.readonly";
+    const post = vi.fn();
+    const patch = vi.fn();
+    const dashboard = { get: vi.fn(), post, patch } as unknown as AxiosInstance;
+
+    dashboard.get = vi.fn().mockResolvedValueOnce({ status: 404 });
+    await ensureIntegration(dashboard, "gmail", "google-mail", "client", "secret", scopes);
+    expect(post).toHaveBeenCalledWith("/api/v1/integrations", expect.objectContaining({
+      provider: "google-mail",
+      auth: expect.objectContaining({ scopes }),
+    }), { params: { env: "dev" } });
+
+    dashboard.get = vi.fn().mockResolvedValueOnce({ status: 200, data: { data: { integration: { oauth_scopes: null } } } });
+    await ensureIntegration(dashboard, "gmail", "google-mail", "client", "secret", scopes);
+    expect(patch).toHaveBeenCalledWith("/api/v1/integrations/gmail", { authType: "OAUTH2", scopes }, { params: { env: "dev" } });
+
+    patch.mockClear();
+    dashboard.get = vi.fn().mockResolvedValueOnce({ status: 200, data: { data: { integration: { oauth_scopes: scopes } } } });
+    await ensureIntegration(dashboard, "gmail", "google-mail", "client", "secret", scopes);
+    expect(patch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 改动说明

- 优化工作区、设置页、日记页与 Agent 状态页的过渡和自适应布局，修正 Agent 马形动画。
- 改造 Context Room 的知识推荐空状态：突出“和 Agent 说”主操作，并将历史归类收纳为可展开区域。
- 补充 Wiki 树在 Context Room 懒加载样式到位前的基础样式，并优化移动端 Agent 面板的展示稳定性。
- 修复右侧智能区抽屉：打开时固定锚定右侧，避免被工作区遮挡；已打开时点击“和 Agent 说”会聚焦输入框并提供平滑提示动画。

## 后续安排

- Nango 相关的后续修复与说明补齐将单独在下一次更新中完成，本次不再调整。

## 验证

- `pnpm --filter @nxcore/desktop test -- tests/knowledge-pending-panel.test.tsx`
- `pnpm --filter @nxcore/desktop typecheck`
- `pnpm --filter @nxcore/gateway test -- tests/nango-bootstrap.test.ts`
- `git diff --check`

## 隐私检查

未包含 `.env`、临时测试目录或 `outputs/` 中的产物。