### PR TITLE
修复：兼容飞书 Issue 附件和单值字段

### DIFF
--- a/.github/workflows/feishu-issue-create.yml
+++ b/.github/workflows/feishu-issue-create.yml
@@ -27,18 +27,22 @@ jobs:
             const requestId = String(input.request_id ?? '');
             const title = String(input.title ?? '').trim();
             const body = String(input.body ?? '');
-            const assignees = Array.isArray(input.assignees) ? [...new Set(input.assignees)] : null;
-            const attachments = Array.isArray(input.attachments) ? [...new Set(input.attachments)] : null;
+            const assignees = input.assignees == null
+              ? []
+              : (Array.isArray(input.assignees) ? [...new Set(input.assignees)] : [input.assignees]);
+            const attachments = input.attachments == null
+              ? []
+              : (Array.isArray(input.attachments) ? [...new Set(input.attachments)] : [input.attachments]);
+            const assetPattern = /^!\[[^\]]*\]\(https:\/\/raw\.githubusercontent\.com\/NxcoreAI\/EverRoom\/issue-assets\/(?:\.github\/issue-assets\/)?[A-Za-z0-9._-]+\)$/;
 
             if (!/^[0-9a-f]{32}$/.test(requestId)
                 || !title || title.length > 256
                 || !body.trim() || body.length > 60000
-                || !assignees || !attachments
                 || assignees.length > 10
                 || assignees.some((login) => typeof login !== 'string'
                   || !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login))
                 || attachments.some((line) => typeof line !== 'string'
-                  || !line.startsWith('![群内截图](https://raw.githubusercontent.com/NxcoreAI/EverRoom/issue-assets/.github/issue-assets/'))) {
+                  || !assetPattern.test(line))) {
               core.setFailed('Invalid Feishu Issue payload.');
               return;
             }


### PR DESCRIPTION
修复飞书 Issue 机器人工作流对附件与可选字段的输入校验问题：

- 兼容单个或多个图片附件。
- 兼容没有指派人的 Issue 草稿。
- 保留 NxcoreAI/EverRoom 仓库和 issue-assets 分支路径校验。
- 修复后，飞书确认创建的 Issue 可以由 github-actions[bot] 创建。