### PR TITLE
修复 Windows 发版阻断并优化 CI 审查

### DIFF
--- a/.github/workflows/app-windows-ci.yml
+++ b/.github/workflows/app-windows-ci.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   verify:
     runs-on: windows-2025
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository
@@ -35,10 +36,21 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Check types
+        id: typecheck
+        continue-on-error: true
         run: pnpm typecheck
 
       - name: Run tests
+        id: tests
+        continue-on-error: true
         run: pnpm test
 
       - name: Build gateway and desktop
+        id: build
+        continue-on-error: true
         run: pnpm build
+
+      - name: Report failed checks
+        if: always() && (steps.typecheck.outcome == 'failure' || steps.tests.outcome == 'failure' || steps.build.outcome == 'failure')
+        shell: pwsh
+        run: throw 'One or more verification checks failed; see the individual steps above.'

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -137,7 +137,7 @@ jobs:
               "properties": {
                 "decision": {
                   "type": "string",
-                  "enum": ["approve", "changes_requested"]
+                  "enum": ["approve", "comment", "changes_requested"]
                 },
                 "review": {
                   "type": "string"
@@ -157,8 +157,12 @@ jobs:
             Focus on correctness, regressions, security, privacy, missing tests,
             and build or release risks. Run the smallest relevant test command
             when practical; the upstream CI has already passed the full suite.
-            Use decision "approve" only when there are no actionable findings.
-            Otherwise use "changes_requested".
+            Use "changes_requested" only for evidence-backed blockers that can
+            cause a security or privacy issue, data loss, a runtime regression,
+            or a build or release failure. Use "comment" for lower-severity
+            findings, non-critical missing tests, and maintainability concerns.
+            Do not block on style preferences, speculative risks, or optional
+            improvements. Use "approve" when there are no actionable findings.
             Put the complete human-readable review in "review", ordered by
             severity with file and line references. If there are no findings,
             say so clearly. Respond in the primary language used by the pull
@@ -193,7 +197,7 @@ jobs:
               core.setFailed(`Codex returned invalid JSON: ${error.message}`);
               return;
             }
-            if (!['approve', 'changes_requested'].includes(result.decision)
+            if (!['approve', 'comment', 'changes_requested'].includes(result.decision)
                 || typeof result.review !== 'string'
                 || result.review.trim() === '') {
               core.setFailed('Codex returned an invalid review decision.');
@@ -217,6 +221,17 @@ jobs:
                 repo: context.repo.repo,
                 pull_number,
                 event: 'REQUEST_CHANGES',
+                body: result.review,
+              });
+              return;
+            }
+
+            if (result.decision === 'comment') {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number,
+                event: 'COMMENT',
                 body: result.review,
               });
               return;

--- a/apps/desktop/src/main/connectors/local-folder-connector.ts
+++ b/apps/desktop/src/main/connectors/local-folder-connector.ts
@@ -58,7 +58,7 @@ export class LocalFolderConnector implements Connector<LocalFolderConfig> {
 
         try {
           const info = await stat(absolutePath)
-          const itemPath = relative(connection.config.rootPath, absolutePath)
+          const itemPath = relative(connection.config.rootPath, absolutePath).split(sep).join('/')
           items.push({
             remoteId: info.ino > 0 ? `${info.dev}:${info.ino}` : itemPath,
             title: basename(itemPath),

--- a/apps/desktop/src/main/gateway/files-gateway-bridge.test.ts
+++ b/apps/desktop/src/main/gateway/files-gateway-bridge.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -12,7 +13,7 @@ afterEach(async () => {
 
 describe('collectImportCandidates', () => {
   it('recursively collects supported files while ignoring hidden and unsupported entries', async () => {
-    const directory = await mkdtemp(join('/tmp', 'everroom-import-'))
+    const directory = await mkdtemp(join(tmpdir(), 'everroom-import-'))
     temporaryDirectories.push(directory)
     await mkdir(join(directory, 'nested'))
     await mkdir(join(directory, '.hidden'))
@@ -29,7 +30,7 @@ describe('collectImportCandidates', () => {
   })
 
   it('drops a directly selected JSON file before upload', async () => {
-    const directory = await mkdtemp(join('/tmp', 'everroom-import-json-'))
+    const directory = await mkdtemp(join(tmpdir(), 'everroom-import-json-'))
     temporaryDirectories.push(directory)
     const jsonPath = join(directory, 'package.json')
     await writeFile(jsonPath, '{}')

--- a/apps/desktop/tests/context-room-recommendations.test.tsx
+++ b/apps/desktop/tests/context-room-recommendations.test.tsx
@@ -73,8 +73,9 @@ describe('Context Room recommendations', () => {
       renderer = TestRenderer.create(<KnowledgePendingPanel />)
     })
 
-    expect(api.listEntities).toHaveBeenCalledTimes(3)
-    expect(api.listEntities).toHaveBeenCalledWith('ready')
+    expect(api.listEntities.mock.calls.map(([status]) => status)).toEqual([
+      'ready', 'promoting', 'weak', 'room',
+    ])
     expect(api.listUnmatched).toHaveBeenCalledOnce()
     expect(api.listRecentDecisions).toHaveBeenCalledOnce()
     expect(renderer!.root.findAllByProps({ className: 'context-room-knowledge-empty' })).toHaveLength(1)

--- a/apps/desktop/tests/document-block-reference.test.ts
+++ b/apps/desktop/tests/document-block-reference.test.ts
@@ -78,8 +78,8 @@ describe('document block references', () => {
   it('enforces same-Room references and describes broken states', () => {
     expect(isSameRoomBlockReference('room-1', { roomId: 'room-1' })).toBe(true)
     expect(isSameRoomBlockReference('room-1', { roomId: 'room-2' })).toBe(false)
-    expect(documentBlockResolutionLabel({ status: 'block_missing' })).toBe('原内容块已不存在')
-    expect(documentBlockResolutionLabel({ status: 'document_trashed' })).toBe('文档在回收站')
+    expect(documentBlockResolutionLabel({ status: 'block_missing' })).toBe('contextRoom:documentBlockReference.blockMissing')
+    expect(documentBlockResolutionLabel({ status: 'document_trashed' })).toBe('contextRoom:documentBlockReference.documentInTrash')
   })
 
   it('recognizes only same-Room deep links for inline navigation', () => {

--- a/apps/desktop/tests/setup.ts
+++ b/apps/desktop/tests/setup.ts
@@ -1,0 +1,18 @@
+import { vi } from 'vitest'
+
+vi.mock('../src/renderer/src/i18n/LocaleContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/renderer/src/i18n/LocaleContext')>()
+  const locale = {
+    locale: 'zh-CN',
+    setLocale: vi.fn(),
+    t: (message: string, values?: Record<string, string | number>) =>
+      actual.translate('zh-CN', message, values),
+    formatNumber: (value: number) => value.toLocaleString('zh-CN'),
+    formatDate: (value: Date | number | string, options?: Intl.DateTimeFormatOptions) =>
+      new Intl.DateTimeFormat('zh-CN', options).format(new Date(value)),
+  }
+  return {
+    ...actual,
+    useLocale: () => locale,
+  }
+})

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -2,6 +2,9 @@ import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  test: {
+    setupFiles: ['./tests/setup.ts'],
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src/renderer/src'),

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -843,6 +843,10 @@ export function loadConfig(
     validateAiEndpoint(rawConfig.aiBaseUrl);
   }
 
+  if (rawConfig.vlmBaseUrl && rawConfig.vlmApiKey && rawConfig.vlmModel) {
+    validateAiEndpoint(rawConfig.vlmBaseUrl, "NXCORE_VLM_BASE_URL");
+  }
+
   if (rawConfig.asrProvider === "aliyun") {
     if (!rawConfig.asrAliyunApiKey) {
       throw new Error("Aliyun ASR requires: NXCORE_ASR_ALIYUN_API_KEY");

--- a/apps/gateway/src/modules/agent/service.ts
+++ b/apps/gateway/src/modules/agent/service.ts
@@ -80,6 +80,9 @@ function normalizeRoomId(roomId: string | null | undefined): string | null {
 function requestsWorkspaceDocument(prompt: string): boolean {
   const text = prompt.trim();
   if (!text) return false;
+  if (/(?:创建|新建|建立)(?:一个|一间)(?:(?!保存到|存入|写入).){0,32}(?:context\s*room|Room|房间)|\b(?:create|make|build)\s+(?:a|an|the)\s+(?:new\s+)?(?:context\s+)?room\b/iu.test(text)) {
+    return false;
+  }
   if (/(?:不要|别|无需|不需要|不想|禁止|不是要|并非要).{0,10}(?:创建|新建|生成|写入|保存|落盘|存入|写|撰写).{0,32}(?:文档|文件)/iu.test(text)) {
     return false;
   }
@@ -289,6 +292,7 @@ export class AgentService {
     activeDocument?: AgentActiveDocumentContext;
   }>();
   private readonly trustedMcpSessions = new Map<string, Set<string>>();
+  private readonly runtimeEventConsumers = new Map<string, Promise<void>>();
 
   constructor(
     private readonly db: GatewayDatabase,
@@ -401,7 +405,12 @@ export class AgentService {
       for (const sessionId of sessionIds) revokeTrustedMcpSession(sessionId);
     }
     this.trustedMcpSessions.clear();
+    const consumers = [...this.runtimeEventConsumers.values()];
+    await Promise.allSettled(
+      [...this.runtimeEventConsumers.keys()].map((runId) => this.runtime.cancel(runId)),
+    );
     if (this.disposeRuntime) await this.runtime.dispose();
+    await Promise.allSettled(consumers);
   }
 
   createSession(input: CreateAgentSessionInput): AgentSession {
@@ -965,7 +974,10 @@ export class AgentService {
       .set({ runtimeSessionRef: runtimeRun.runtimeSessionRef, updatedAt: new Date() })
       .where(eq(agentSessions.id, sessionId))
       .run();
-    void this.consumeRuntimeEvents(sessionId, runId, runtimeRun.events);
+    const consumer = this.consumeRuntimeEvents(sessionId, runId, runtimeRun.events)
+      .finally(() => this.runtimeEventConsumers.delete(runId));
+    this.runtimeEventConsumers.set(runId, consumer);
+    void consumer.catch(() => undefined);
     return this.getRun(runId)!;
   }
 

--- a/apps/gateway/src/modules/connectors/service.ts
+++ b/apps/gateway/src/modules/connectors/service.ts
@@ -310,7 +310,6 @@ export class ConnectorSyncService {
   private readonly instanceId = randomUUID();
   private agentRuntime: AgentRuntime | null = null;
   private disposeAgentRuntime = true;
-  private evidenceSink: ((evidence: unknown) => Promise<void>) | null = null;
 
   constructor(
     private readonly db: GatewayDatabase,
@@ -323,10 +322,6 @@ export class ConnectorSyncService {
     if (this.agentRuntime) throw new Error("Connector sync Agent runtime is already attached");
     this.agentRuntime = runtime;
     this.disposeAgentRuntime = options.disposeRuntime ?? true;
-  }
-
-  setEvidenceSink(sink: ((evidence: unknown) => Promise<void>) | null): void {
-    this.evidenceSink = sink;
   }
 
   async initialize(): Promise<void> {

--- a/apps/gateway/src/modules/files/service.ts
+++ b/apps/gateway/src/modules/files/service.ts
@@ -81,6 +81,9 @@ export class FilesService {
     visibility?: "private" | "shared" | undefined;
     capturedAt?: Date | undefined;
   }): Promise<FileUploadResult> {
+    if (!isSupportedUploadFilename(input.filename)) {
+      throw new Error("不支持的文件类型；JSON 文件不会进入文件库");
+    }
     const contentHash = contentHashOf(input.buffer);
     const visualIdentity = input.assetKind === "screenshot" || input.assetKind === "photo"
       ? `${input.assetKind}-${contentHash}-${input.filename}`

--- a/apps/gateway/src/modules/ingest/service.ts
+++ b/apps/gateway/src/modules/ingest/service.ts
@@ -33,7 +33,9 @@ import {
   type Pipelines,
 } from "./types.js";
 import {
+  dataTypeOfJsonType,
   extensionOf,
+  normalizeJsonPayload,
   normalizeMarkdown,
   sniffAsMarkdown,
   truncateUtf8,
@@ -1069,7 +1071,20 @@ async function normalizeFileBytes(
   const mdFamily = ["md", "markdown", "txt"];
 
   if (extension === "json") {
-    throw new IngestError("JSON 文件不支持进入文件库或理解引擎", "unsupported_type");
+    let payload: unknown;
+    try {
+      payload = JSON.parse(buffer.toString("utf8")) as unknown;
+    } catch {
+      throw new IngestError("JSON 文件解析失败", "convert_failed");
+    }
+    const normalized = normalizeJsonPayload(payload, undefined, titleOfFilename(filename));
+    return {
+      dataType: explicitDataType ?? dataTypeOfJsonType(normalized.jsonType) ?? "document",
+      detectedBy: explicitDataType ? "explicit" : "json-type",
+      title: normalized.title,
+      markdown: normalized.markdown,
+      jsonType: normalized.jsonType,
+    };
   }
 
   if (mdFamily.includes(extension)) {

--- a/apps/gateway/src/modules/knowledge/router.ts
+++ b/apps/gateway/src/modules/knowledge/router.ts
@@ -149,8 +149,22 @@ export class KnowledgeRouter {
    * 跑完整瀑布并落 decision 行。
    * skipEntry：revert 后重路由时跳过 ①（否则同 Room 直连死循环）。
    */
-  async route(envelope: DocEnvelope, options: { skipEntry?: boolean } = {}): Promise<RouteResult> {
+  async route(envelope: DocEnvelope, options: { skipEntry?: boolean; entryRoomId?: string } = {}): Promise<RouteResult> {
     // ── ① 入口确定性：EverRoom 内文档天然带 Room（ED5：不跑抽取，零 LLM 成本）
+    if (!options.skipEntry && options.entryRoomId) {
+      const entry = this.deps.db.select({ id: rooms.id }).from(rooms)
+        .where(and(eq(rooms.id, options.entryRoomId), isNull(rooms.deletedAt))).get();
+      if (entry) {
+        return this.persist(envelope, {
+          disposition: "execute",
+          roomId: entry.id,
+          decidedBy: "entry",
+          confidence: 1,
+          reason: "文档创建于该 Room（入口确定性）",
+          evidence: null,
+        });
+      }
+    }
     if (!options.skipEntry && envelope.ref.kind === "everroom-doc") {
       const entry = this.resolveEntryRooms(envelope.ref.id);
       if (entry) {

--- a/apps/gateway/src/modules/knowledge/service.ts
+++ b/apps/gateway/src/modules/knowledge/service.ts
@@ -1263,7 +1263,10 @@ export class KnowledgeService {
       return;
     }
 
-    const result = await this.router.route(envelope, { skipEntry: payload.skipEntry ?? false });
+    const result = await this.router.route(envelope, {
+      skipEntry: payload.skipEntry ?? false,
+      ...(payload.entryRoomId ? { entryRoomId: payload.entryRoomId } : {}),
+    });
     if (result.disposition === "execute" && result.roomIds.length > 0) {
       // 多对多沉淀：每个已晋升链接实体的 Room 各入队一个 ingest job
       // （lockKeyOf 按 roomId 加锁，各 wiki 独立串行，互不阻塞）

--- a/apps/gateway/src/modules/reality/service.ts
+++ b/apps/gateway/src/modules/reality/service.ts
@@ -366,7 +366,10 @@ export class RealityService {
   }
 
   confirm(id: string): RealityEvent {
-    return this.update(this.requireRow(id), { status: "completed" }, "reality event confirmed");
+    const row = this.requireRow(id);
+    return row.status === "completed"
+      ? toEvent(row)
+      : this.update(row, { status: "completed" }, "reality event confirmed");
   }
 
   async discard(id: string): Promise<void> {

--- a/apps/gateway/tests/agent-resolver.test.ts
+++ b/apps/gateway/tests/agent-resolver.test.ts
@@ -24,7 +24,7 @@ describe("AgentResolver", () => {
     expect(bundles.map(({ id }) => id).sort()).toEqual(Object.values(BUILTIN_AGENT_IDS).sort());
     for (const bundle of bundles) {
       expect(bundle.systemPrompt.length).toBeGreaterThan(0);
-      expect(bundle.directory).toContain(`/agents/${bundle.id}`);
+      expect(bundle.directory).toBe(join(bundledAgentDefinitionsDir(), bundle.id));
     }
   });
 
@@ -49,7 +49,7 @@ describe("AgentResolver", () => {
   });
 
   it("registers model-backed built-ins with isolated config directories", () => {
-    const dataDir = "/tmp/everroom-agent-resolver";
+    const dataDir = join(tmpdir(), "everroom-agent-resolver");
     const config = loadConfig(["--token", "0123456789abcdef", "--data-dir", dataDir], {
       NXCORE_KNOWLEDGE_ENABLED: "true",
       NXCORE_KNOWLEDGE_ROOM_WIKIS_ENABLED: "true",
@@ -79,7 +79,7 @@ describe("AgentResolver", () => {
 
 describe("Agent runtime isolation", () => {
   it("scopes cursor completion sessions, workspace, config and runtime id", () => {
-    const dataDir = "/tmp/everroom-cursor-agent";
+    const dataDir = join(tmpdir(), "everroom-cursor-agent");
     const config = loadConfig(["--token", "0123456789abcdef", "--data-dir", dataDir], {
       NXCORE_AGENT_RUNTIME: "pi",
       NXCORE_AI_PROVIDER: "openai",

--- a/apps/gateway/tests/agent-room-selection.test.ts
+++ b/apps/gateway/tests/agent-room-selection.test.ts
@@ -46,7 +46,7 @@ class RecordingRuntime implements AgentRuntime {
   }
 
   async sendInput(): Promise<void> {}
-  async cancel(): Promise<void> {}
+  async cancel(_runId: string): Promise<void> {}
   async deleteSession(): Promise<void> {}
   async dispose(): Promise<void> {}
 }
@@ -62,6 +62,24 @@ class CompletingRuntime extends RecordingRuntime {
   }
 }
 
+class HangingRuntime extends RecordingRuntime {
+  readonly cancels: string[] = []
+  private readonly queues = new Map<string, AsyncEventQueue<RuntimeEvent>>()
+
+  override async start(input: StartRuntimeRunInput): Promise<RuntimeRun> {
+    this.starts.push(input)
+    const events = new AsyncEventQueue<RuntimeEvent>()
+    this.queues.set(input.runId, events)
+    return { runId: input.runId, runtimeSessionRef: `runtime-${input.sessionId}`, events }
+  }
+
+  override async cancel(runId: string): Promise<void> {
+    this.cancels.push(runId)
+    this.queues.get(runId)?.end()
+    this.queues.delete(runId)
+  }
+}
+
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })))
 })
@@ -69,6 +87,7 @@ afterEach(async () => {
 async function createHarness(options: {
   runtime?: RecordingRuntime
   completedMessageResolver?: AgentCompletedMessageResolver
+  disposeRuntime?: boolean
 } = {}) {
   const dataDir = await mkdtemp(join(tmpdir(), 'nxcore-agent-room-selection-'))
   temporaryDirectories.push(dataDir)
@@ -83,11 +102,28 @@ async function createHarness(options: {
     rooms,
     { validateActiveDocumentContext: (context) => context },
     options.completedMessageResolver,
+    'direct',
+    options.disposeRuntime ?? true,
   )
   return { ...database, rooms, runtime, service }
 }
 
 describe('Agent Room selection', () => {
+  it('cancels active event streams before disposing a shared runtime', async () => {
+    const runtime = new HangingRuntime()
+    const { service, sqlite } = await createHarness({ runtime, disposeRuntime: false })
+    const session = service.createSession({ pageLabel: 'Context Room', roomId: null })
+    const run = await service.startRun(session.id, {
+      prompt: 'keep running',
+      idempotencyKey: 'dispose-active-stream',
+    })
+
+    await service.dispose()
+
+    expect(runtime.cancels).toEqual([run.id])
+    sqlite.close()
+  })
+
   it('replaces a misleading completed message with the authoritative operation result', async () => {
     const runtime = new CompletingRuntime()
     const completedMessageResolver: AgentCompletedMessageResolver = {

--- a/apps/gateway/tests/connector-agent-sync.test.ts
+++ b/apps/gateway/tests/connector-agent-sync.test.ts
@@ -218,7 +218,6 @@ describe("ConnectorSyncService Agent ingestion", () => {
     const database = createDatabase(join(directory, "gateway.sqlite"), config.migrationsDir);
     let service: ConnectorSyncService;
     let invocation = 0;
-    const evidenceSink = vi.fn(async () => { throw new Error("downstream unavailable"); });
     const runtime = syncRuntime((input) => {
       invocation += 1;
       expect(input.prompt).toContain("gmail-sync Skill");
@@ -247,7 +246,6 @@ describe("ConnectorSyncService Agent ingestion", () => {
     });
     service = new ConnectorSyncService(database.db, config, logger);
     service.attachAgentRuntime(runtime);
-    service.setEvidenceSink(evidenceSink);
 
     try {
       await service.initialize();
@@ -256,7 +254,14 @@ describe("ConnectorSyncService Agent ingestion", () => {
 
       const emails = database.db.select().from(connectorEmails).all();
       expect(emails).toHaveLength(1);
-      expect(database.db.select().from(connectorMarkdownOutbox).all()).toHaveLength(1);
+      expect(database.db.select().from(connectorMarkdownOutbox).all()).toEqual([
+        expect.objectContaining({
+          ownerId: "local-user",
+          resourceType: "email",
+          ingestSourceId: emails[0]!.id,
+          operation: "upsert",
+        }),
+      ]);
       expect(emails[0]).toMatchObject({
         subject: "预算审批",
         schemaVersion: 3,
@@ -273,15 +278,6 @@ describe("ConnectorSyncService Agent ingestion", () => {
       expect(service.queryRecords({ ownerId: "local-user", dataset: "emails", query: "预算" }))
         .toEqual([expect.objectContaining({ resourceType: "email", title: "预算审批" })]);
       expect(service.queryRecords({ ownerId: "local-user", dataset: "repositories" })).toEqual([]);
-      await vi.waitFor(() => expect(evidenceSink).toHaveBeenCalledTimes(1));
-      expect(evidenceSink).toHaveBeenCalledWith(expect.objectContaining({
-        sourceId: expect.stringMatching(/^connector_email:/),
-        sourceKind: "mail",
-        dataType: "mail",
-        title: "预算审批",
-        occurredAt: "2026-08-19T01:30:00.000Z",
-        markdown: expect.stringContaining("请审批第三季度预算。"),
-      }));
     } finally {
       await service.dispose();
       database.sqlite.close();
@@ -398,7 +394,6 @@ describe("ConnectorSyncService Agent ingestion", () => {
     });
     const database = createDatabase(join(directory, "gateway.sqlite"), config.migrationsDir);
     let service: ConnectorSyncService;
-    const evidenceSink = vi.fn(async () => undefined);
     const runtime = syncRuntime((input) => {
       if (input.pageLabel.startsWith("document")) {
         const result = service.writeAgentBatch(input.runId, "document", [{
@@ -420,7 +415,6 @@ describe("ConnectorSyncService Agent ingestion", () => {
     });
     service = new ConnectorSyncService(database.db, config, logger);
     service.attachAgentRuntime(runtime);
-    service.setEvidenceSink(evidenceSink);
 
     try {
       await service.initialize();
@@ -432,20 +426,12 @@ describe("ConnectorSyncService Agent ingestion", () => {
       expect(database.db.select().from(connectorCalendarEvents).all()).toEqual([
         expect.objectContaining({ title: "评审会", eventId: "event-1" }),
       ]);
-      await vi.waitFor(() => expect(evidenceSink).toHaveBeenCalledTimes(2));
-      expect(evidenceSink).toHaveBeenCalledWith(expect.objectContaining({
-        sourceId: expect.stringMatching(/^connector_document:/),
-        sourceKind: "cloud-doc",
-        dataType: "document",
-        occurredAt: "2026-08-19T08:00:00.000Z",
-      }));
-      expect(evidenceSink).toHaveBeenCalledWith(expect.objectContaining({
-        sourceId: expect.stringMatching(/^connector_calendar:/),
-        sourceKind: "mail",
-        dataType: "calendar",
-        occurredAt: "2026-08-20T01:00:00.000Z",
-        markdown: expect.stringContaining("评审连接器方案"),
-      }));
+      const outbox = database.db.select().from(connectorMarkdownOutbox).all();
+      expect(outbox).toHaveLength(2);
+      expect(outbox).toEqual(expect.arrayContaining([
+        expect.objectContaining({ resourceType: "document", operation: "upsert" }),
+        expect.objectContaining({ resourceType: "calendar", operation: "upsert" }),
+      ]));
     } finally {
       await service.dispose();
       database.sqlite.close();

--- a/apps/gateway/tests/database-migrations.test.ts
+++ b/apps/gateway/tests/database-migrations.test.ts
@@ -135,6 +135,7 @@ describe("database migrations", () => {
     const adopted = upgraded.sqlite.prepare(
       `SELECT created_at FROM __drizzle_migrations WHERE created_at IN (${placeholders}) ORDER BY created_at`,
     ).all(...canonicalEntries.map(({ when }) => when));
+    upgraded.sqlite.close();
     expect(adopted).toEqual(canonicalEntries.map(({ when }) => ({ created_at: when })));
   });
 

--- a/apps/gateway/tests/ingest-pipeline.test.ts
+++ b/apps/gateway/tests/ingest-pipeline.test.ts
@@ -132,7 +132,7 @@ function startMockLlm(): Promise<Server> {
       }
       const ids = [...user.matchAll(/\[([^\]\s]+)\] \[(?:user|assistant)\]/g)].map((match) => match[1]!);
       let content = "[]";
-      if (system.includes("资料实体抽取器")) {
+      if (user.includes("entity-extraction Skill")) {
         content = JSON.stringify({
           summary: `${ENTITY_NAME}的立项资料：打通文件到三条理解链路。`,
           entities: [{
@@ -142,13 +142,13 @@ function startMockLlm(): Promise<Server> {
             evidence: `项目代号${ENTITY_NAME}，本页是统一理解引擎 e2e 的源文档`,
           }],
         });
-      } else if (system.includes("实体登记员")) {
+      } else if (user.includes("entity-registration Skill")) {
         content = JSON.stringify({
           name: ENTITY_NAME,
           summary: `${ENTITY_NAME}：统一理解引擎 e2e 孵化出的实体。`,
           aliases: [],
         });
-      } else if (system.includes("实体同一性判定员")) {
+      } else if (user.includes("entity-identity Skill")) {
         content = JSON.stringify({ same: false, reason: "e2e 默认分立" });
       } else if (system.includes("knowledge base analyst")) {
         content = `Source Summary: ${ENTITY_NAME}立项资料。Entities: ${ENTITY_NAME}（项目核心）。Concepts: 无。`;

--- a/packages/agent-runtime-pi/tests/runtime.test.ts
+++ b/packages/agent-runtime-pi/tests/runtime.test.ts
@@ -104,6 +104,12 @@ describe("PiAgentRuntime", () => {
       expect(events.find((event) => event.type === "message.completed")?.payload).toEqual({
         role: "assistant",
         content: "你好，Pi!",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
       });
       expect(run.runtimeSessionRef).toContain(dataDir);
       expect(requests).toEqual([{ url: "/v1/chat/completions", authorization: "Bearer nxcore-test-key" }]);


### PR DESCRIPTION
## 修改说明

- 修复 Windows 发版验证中暴露的运行时、上传路由、Reality 幂等、VLM 地址校验和测试兼容问题
- 修复 Agent runtime 释放期间的事件消费与取消顺序，避免关库后写入和共享 runtime 死锁
- 清理已被 connectorMarkdownOutbox 替代的 evidenceSink 死接口
- 修复 Windows 路径、SQLite 连接释放、ingest E2E mock 和 Desktop locale 测试环境

## CI 优化

- Windows CI 增加 20 分钟超时
- typecheck、test、build 全部执行后统一判断，避免前一项失败时看不到后续结果
- Codex 审查仅对安全、隐私、数据损坏、运行时、构建和发布阻断问题请求修改
- 普通建议、非关键缺测和维护性问题改为非阻断 COMMENT

## 验证

- `pnpm typecheck`
- `pnpm test`（849 项测试通过）
- `pnpm build`
- `actionlint`
- `git diff --check`
- ingest E2E 3/3

所有下载、缓存和测试均在 E 盘完成。