### PR TITLE
修复 Windows CI 日记测试时区依赖

### DIFF
--- a/apps/gateway/tests/diary-service.test.ts
+++ b/apps/gateway/tests/diary-service.test.ts
@@ -26,12 +26,14 @@ async function setup(generator?: DiaryGenerator, memory?: DiaryMemoryProvider, m
   temporaryDirectories.push(dir);
   const database = createDatabase(join(dir, "gateway.sqlite"), resolve("drizzle"));
   databases.push(database);
-  return { database, service: new DiaryService(database.db, {
+  const service = new DiaryService(database.db, {
     ...(generator ? { generator } : {}),
     ...(memory ? { memory } : {}),
     now: () => new Date(NOW),
     maxAttempts,
-  }) };
+  });
+  service.updateSettings({ timezone: "Asia/Shanghai" });
+  return { database, service };
 }
 
 afterEach(async () => {


### PR DESCRIPTION
## 问题

GitHub Windows runner 使用 UTC，而日记服务测试依赖开发机的 `Asia/Shanghai` 系统时区，导致来源窗口、生成调用和下次调度断言失败。

## 修复

在日记服务测试的统一 `setup()` 中显式设置 `Asia/Shanghai`。不修改生产逻辑、不增加依赖。

## 验证

在 `TZ=UTC` 环境执行：

- 日记服务测试：14/14 通过
- 全仓测试：849 项通过