### PR TITLE
修复桌面安装包自包含运行时并增加冷启动校验

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -62,8 +62,11 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Build gateway and desktop
-        run: pnpm build
+      - name: Build app and bundled runtimes
+        run: |
+          pnpm build
+          pnpm --filter @nxcore/desktop exec node scripts/prepare-open-connector.mjs
+          pnpm --filter @nxcore/desktop exec node scripts/prepare-oo-cli.mjs
 
       - name: Package macOS arm64
         run: pnpm --filter @nxcore/desktop exec electron-builder --mac dmg zip --arm64 --publish never
@@ -74,13 +77,15 @@ jobs:
           app_path="$(find release -type d -name EverRoom.app -print -quit)"
           test -n "$app_path" || { echo "EverRoom.app was not produced" >&2; exit 1; }
           resources="$app_path/Contents/Resources"
-          forbidden='(^|/)(\.env($|\.)|(__tests__|tests?)(/|$)|[^/]*(\.test|\.spec)\.[^/]+$|(test|spec)\.[^/]+$)|\.(map|ts|tsx|mts|cts)$'
+          forbidden='(^|/)(\.env($|\.)|(__tests__|tests?)(/|$)|[^/]*(\.test|\.spec)\.[^/]+$|(test|spec)\.[^/]+$)|\.map$'
 
           loose_files="$(find "$resources" -type f -print)"
           if printf '%s\n' "$loose_files" | grep -Eiq "$forbidden"; then
             printf '%s\n' "$loose_files" | grep -Ei "$forbidden" >&2
             exit 1
           fi
+          unexpected_typescript="$(printf '%s\n' "$loose_files" | grep -Ei '\.(ts|tsx|mts|cts)$' | grep -Ev "^$resources/open-connector/" || true)"
+          test -z "$unexpected_typescript" || { printf '%s\n' "$unexpected_typescript" >&2; exit 1; }
 
           asar_path="$(cd "$resources" && pwd)/app.asar"
           pnpm --filter @nxcore/desktop exec asar list "$asar_path" > "$RUNNER_TEMP/asar-files.txt"
@@ -88,6 +93,20 @@ jobs:
             grep -Ei "$forbidden" "$RUNNER_TEMP/asar-files.txt" >&2
             exit 1
           fi
+          unexpected_typescript="$(grep -Ei '\.(ts|tsx|mts|cts)$' "$RUNNER_TEMP/asar-files.txt" | grep -Eiv '[\\/]node_modules[\\/]@tencentdb-agent-memory[\\/](memory-tencentdb-v2|knowledge-service)[\\/]src[\\/]' || true)"
+          test -z "$unexpected_typescript" || { printf '%s\n' "$unexpected_typescript" >&2; exit 1; }
+
+          grep -Fq 'memory-tencentdb-v2/bin/memory-gateway.mjs' "$RUNNER_TEMP/asar-files.txt"
+          grep -Fq 'memory-tencentdb-v2/src/gateway/server.ts' "$RUNNER_TEMP/asar-files.txt"
+          grep -Fq 'knowledge-service/src/server.ts' "$RUNNER_TEMP/asar-files.txt"
+          grep -Fq '@node-rs/jieba-darwin-arm64' "$RUNNER_TEMP/asar-files.txt"
+          grep -Fq '@colbymchenry/codegraph-darwin-arm64' "$RUNNER_TEMP/asar-files.txt"
+          test -x "$resources/app.asar.unpacked/node_modules/@esbuild/darwin-arm64/bin/esbuild"
+          test -f "$resources/app.asar.unpacked/node_modules/better-sqlite3/prebuilds/darwin-arm64.node"
+          test -f "$resources/open-connector/src/server/index.ts"
+          test -f "$resources/open-connector/dist/web/index.html"
+          test -x "$resources/oo/darwin-arm64/oo"
+          "$resources/oo/darwin-arm64/oo" --version
 
       - name: Verify artifacts
         shell: bash
@@ -161,8 +180,11 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Build gateway and desktop
-        run: pnpm build
+      - name: Build app and bundled runtimes
+        run: |
+          pnpm build
+          pnpm --filter @nxcore/desktop exec node scripts/prepare-open-connector.mjs
+          pnpm --filter @nxcore/desktop exec node scripts/prepare-oo-cli.mjs
 
       - name: Package Windows x64
         run: pnpm --filter @nxcore/desktop exec electron-builder --win nsis --x64 --publish never
@@ -176,13 +198,21 @@ jobs:
           if (-not (Test-Path $asar -PathType Leaf)) {
             throw 'app.asar was not produced'
           }
-          $forbidden = '(^|[\\/])(\.env($|\.)|(__tests__|tests?)([\\/]|$)|[^\\/]*(\.test|\.spec)\.[^\\/]+$|(test|spec)\.[^\\/]+$)|\.(map|ts|tsx|mts|cts)$'
+          $forbidden = '(^|[\\/])(\.env($|\.)|(__tests__|tests?)([\\/]|$)|[^\\/]*(\.test|\.spec)\.[^\\/]+$|(test|spec)\.[^\\/]+$)|\.map$'
 
           $looseFiles = Get-ChildItem $resources -File -Recurse | ForEach-Object FullName
           $forbiddenLooseFiles = @($looseFiles | Where-Object { $_ -match $forbidden })
           if ($forbiddenLooseFiles.Count -gt 0) {
             $forbiddenLooseFiles | Write-Error
             throw 'Forbidden loose files found in packaged resources'
+          }
+          $openConnectorRoot = (Resolve-Path (Join-Path $resources 'open-connector')).Path + [IO.Path]::DirectorySeparatorChar
+          $unexpectedLooseTypeScript = @($looseFiles | Where-Object {
+            $_ -match '\.(ts|tsx|mts|cts)$' -and -not $_.StartsWith($openConnectorRoot, [StringComparison]::OrdinalIgnoreCase)
+          })
+          if ($unexpectedLooseTypeScript.Count -gt 0) {
+            $unexpectedLooseTypeScript | Write-Error
+            throw 'Unexpected loose TypeScript files found in packaged resources'
           }
 
           $asarFiles = pnpm --filter @nxcore/desktop exec asar list (Resolve-Path $asar)
@@ -193,6 +223,85 @@ jobs:
           if ($forbiddenAsarFiles.Count -gt 0) {
             $forbiddenAsarFiles | Write-Error
             throw 'Forbidden files found in app.asar'
+          }
+          $allowedTypeScript = '[\\/]node_modules[\\/]@tencentdb-agent-memory[\\/](memory-tencentdb-v2|knowledge-service)[\\/]src[\\/]'
+          $unexpectedAsarTypeScript = @($asarFiles | Where-Object {
+            $_ -match '\.(ts|tsx|mts|cts)$' -and $_ -notmatch $allowedTypeScript
+          })
+          if ($unexpectedAsarTypeScript.Count -gt 0) {
+            $unexpectedAsarTypeScript | Write-Error
+            throw 'Unexpected TypeScript files found in app.asar'
+          }
+
+          foreach ($required in @(
+            'memory-tencentdb-v2[\\/]bin[\\/]memory-gateway.mjs',
+            'memory-tencentdb-v2[\\/]src[\\/]gateway[\\/]server.ts',
+            'knowledge-service[\\/]src[\\/]server.ts',
+            '@node-rs[\\/]jieba-win32-x64-msvc[\\/]jieba.win32-x64-msvc.node',
+            '@colbymchenry[\\/]codegraph-win32-x64'
+          )) {
+            if (-not ($asarFiles -match $required)) { throw "Missing packaged runtime entry: $required" }
+          }
+          foreach ($required in @(
+            "$resources/app.asar.unpacked/node_modules/@esbuild/win32-x64/esbuild.exe",
+            "$resources/app.asar.unpacked/node_modules/better-sqlite3/prebuilds/win32-x64.node",
+            "$resources/open-connector/src/server/index.ts",
+            "$resources/open-connector/dist/web/index.html",
+            "$resources/oo/win32-x64/oo.exe"
+          )) {
+            if (-not (Test-Path $required -PathType Leaf)) { throw "Missing packaged runtime file: $required" }
+          }
+          & "$resources/oo/win32-x64/oo.exe" --version
+          if ($LASTEXITCODE -ne 0) { throw 'Packaged oo CLI failed to start' }
+
+      - name: Cold-start packaged app
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $testRoot = Join-Path $env:RUNNER_TEMP 'everroom-cold-start'
+          $env:APPDATA = Join-Path $testRoot 'Roaming'
+          $env:LOCALAPPDATA = Join-Path $testRoot 'Local'
+          $env:NXCORE_DATA_DIR = Join-Path $testRoot 'EverRoom'
+          New-Item -ItemType Directory -Force -Path $env:APPDATA, $env:LOCALAPPDATA | Out-Null
+          $stdout = Join-Path $testRoot 'stdout.log'
+          $stderr = Join-Path $testRoot 'stderr.log'
+          $app = Start-Process -FilePath (Resolve-Path 'release/win-unpacked/EverRoom.exe') `
+            -ArgumentList '--disable-gpu' -WindowStyle Hidden -PassThru `
+            -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+          try {
+            $deadline = [DateTime]::UtcNow.AddSeconds(120)
+            $gatewayReady = $false
+            $memoryReady = $false
+            $knowledgeReady = $false
+            while ([DateTime]::UtcNow -lt $deadline -and -not $app.HasExited) {
+              Start-Sleep -Milliseconds 500
+              try {
+                $memoryReady = (Invoke-WebRequest 'http://127.0.0.1:8420/health' -UseBasicParsing -TimeoutSec 2).StatusCode -eq 200
+              } catch {}
+              try {
+                $knowledgeReady = (Invoke-WebRequest 'http://127.0.0.1:8421/health' -UseBasicParsing -TimeoutSec 2).StatusCode -eq 200
+              } catch {}
+              $manifestPath = Join-Path $env:NXCORE_DATA_DIR 'runtime/gateway.json'
+              if (Test-Path $manifestPath -PathType Leaf) {
+                try {
+                  $gateway = Get-Content $manifestPath -Raw | ConvertFrom-Json
+                  $headers = @{ Authorization = "Bearer $($gateway.token)" }
+                  $gatewayReady = (Invoke-WebRequest "$($gateway.baseUrl)/v1/health/ready" -Headers $headers -UseBasicParsing -TimeoutSec 2).StatusCode -eq 200
+                } catch {}
+              }
+              if ($gatewayReady -and $memoryReady -and $knowledgeReady) { break }
+            }
+            if (-not ($gatewayReady -and $memoryReady -and $knowledgeReady)) {
+              Get-Content $stdout -Tail 200 -ErrorAction SilentlyContinue
+              Get-Content $stderr -Tail 200 -ErrorAction SilentlyContinue | Write-Error
+              throw "Packaged app failed health checks: gateway=$gatewayReady memory=$memoryReady knowledge=$knowledgeReady"
+            }
+            Write-Host 'Packaged app cold-start health checks passed'
+          } finally {
+            if (-not $app.HasExited) {
+              $null = $app.CloseMainWindow()
+              if (-not $app.WaitForExit(10_000)) { & taskkill.exe /PID $app.Id /T /F | Out-Null }
+            }
           }
 
       - name: Verify artifacts

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,6 +37,7 @@
     "@tiptap/react": "^3.30.1",
     "@tiptap/starter-kit": "^3.30.1",
     "axios": "^1.19.0",
+    "better-sqlite3": "^13.0.3",
     "d3-force": "^3.0.0",
     "docx": "^9.7.1",
     "gsap": "3.15.0",
@@ -85,6 +86,9 @@
       }
     ],
     "asar": true,
+    "asarUnpack": [
+      "node_modules/@esbuild/**/*"
+    ],
     "directories": {
       "output": "../../release"
     },
@@ -94,7 +98,9 @@
       "!**/{test,tests,__tests__}/**",
       "!**/{test,spec}.*",
       "!**/*.{test,spec}.*",
-      "!**/*.{map,ts,tsx,mts,cts}"
+      "!**/*.{map,ts,tsx,mts,cts}",
+      "node_modules/@tencentdb-agent-memory/memory-tencentdb-v2/src/**/*",
+      "node_modules/@tencentdb-agent-memory/knowledge-service/src/**/*"
     ],
     "extraResources": [
       {

--- a/apps/desktop/src/main/gateway/nango-supervisor.ts
+++ b/apps/desktop/src/main/gateway/nango-supervisor.ts
@@ -164,7 +164,10 @@ export class NangoSupervisor {
     }
 
     // ponytail: 打包形态尚未把 nango 子模块打进 extraResources,先只支持 dev 托管。
-    if (app.isPackaged) throw new Error('Nango 托管目前仅支持开发模式')
+    if (app.isPackaged) {
+      this.runtimeState = 'disabled'
+      return null
+    }
     const nangoDirectory = join(app.getAppPath(), '..', 'gateway', 'src', 'modules', 'connector')
 
     // 复用已在运行的实例(用户手动启动的 Nango 等)。

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -103,10 +103,21 @@ async function rateLimitAware<T>(operation: () => Promise<T>): Promise<T | IpcRa
 }
 
 const appDataDirectory = app.getPath('appData')
-const dataDirectory = join(appDataDirectory, APP_NAME)
+const dataDirectory = process.env.NXCORE_DATA_DIR?.trim() || join(appDataDirectory, APP_NAME)
 
 app.setPath('userData', dataDirectory)
 app.setName(APP_NAME)
+if (app.isPackaged) {
+  const esbuildExecutable = process.platform === 'win32' ? 'esbuild.exe' : join('bin', 'esbuild')
+  process.env.ESBUILD_BINARY_PATH = join(
+    process.resourcesPath,
+    'app.asar.unpacked',
+    'node_modules',
+    '@esbuild',
+    `${process.platform}-${process.arch}`,
+    esbuildExecutable,
+  )
+}
 configureDesktopLogger(dataDirectory)
 configureSentry(app.getVersion(), app.isPackaged)
 if (process.platform === 'darwin') process.title = APP_NAME

--- a/apps/desktop/src/main/knowledge/knowledge-supervisor.ts
+++ b/apps/desktop/src/main/knowledge/knowledge-supervisor.ts
@@ -1,6 +1,6 @@
 import { mkdir } from 'node:fs/promises'
 import { createRequire } from 'node:module'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 
@@ -28,7 +28,6 @@ export interface KnowledgeServiceConnection {
 }
 
 const PACKAGE_NAME = '@tencentdb-agent-memory/knowledge-service'
-const MEMORY_PACKAGE_NAME = '@tencentdb-agent-memory/memory-tencentdb-v2'
 const KNOWLEDGE_PORT = 8421
 const DEFAULT_BASE_URL = `http://127.0.0.1:${KNOWLEDGE_PORT}`
 const SERVICE_ID = 'everroom'
@@ -80,8 +79,6 @@ export class KnowledgeServiceSupervisor {
     await mkdir(dataDir, { recursive: true })
 
     const command = app.isPackaged ? process.execPath : (process.env.NXCORE_KNOWLEDGE_NODE ?? 'node')
-    // Windows + Node 22 的组合下:--import 必须是 file:// URL,而主入口必须是
-    // 正斜杠路径(file:// 会被误判为 CJS 相对路径,反斜杠会被判为 URL scheme)。
     const serverEntry = join(packageDirectory, 'src', 'server.ts').replace(/\\/g, '/')
     const child = spawn(
       command,
@@ -217,30 +214,13 @@ export class KnowledgeServiceSupervisor {
 
   private resolvePackage(): { packageDirectory: string; tsxEntryUrl: string } {
     const override = process.env.NXCORE_KNOWLEDGE_SERVICE_DIR?.trim()
-    if (override) {
-      return { packageDirectory: override, tsxEntryUrl: this.resolveTsx(join(override, 'package.json')) }
-    }
-    if (app.isPackaged) {
-      // 打包态目录(v1 暂未随 extraResources 发布,占位保持与 memory-core 相同的结构)。
-      const packageDirectory = join(process.resourcesPath, 'knowledge-service')
-      return { packageDirectory, tsxEntryUrl: this.resolveTsx(join(packageDirectory, 'package.json')) }
-    }
-    // dev:从 apps/desktop 的 node_modules 解析 git 依赖安装的 knowledge-service 包。
-    // 该包没有 exports 字段,子路径可直接 resolve。
-    const baseRequire = createRequire(join(app.getAppPath(), 'package.json'))
-    const manifestPath = baseRequire.resolve(`${PACKAGE_NAME}/package.json`)
-    return { packageDirectory: join(manifestPath, '..'), tsxEntryUrl: this.resolveTsx(manifestPath) }
-  }
-
-  /** tsx 优先取 knowledge 包自带的依赖;包内缺失时回退到 memory 包(同为桌面依赖树内)。 */
-  private resolveTsx(anchor: string): string {
-    const packageRequire = createRequire(anchor)
-    try {
-      return pathToFileURL(packageRequire.resolve('tsx')).href
-    } catch {
-      const baseRequire = createRequire(join(app.getAppPath(), 'package.json'))
-      const memoryBin = baseRequire.resolve(`${MEMORY_PACKAGE_NAME}/bin/memory-gateway.mjs`)
-      return pathToFileURL(createRequire(memoryBin).resolve('tsx')).href
+    const manifestPath = override
+      ? join(override, 'package.json')
+      : createRequire(join(app.getAppPath(), 'package.json')).resolve(`${PACKAGE_NAME}/package.json`)
+    const packageRequire = createRequire(manifestPath)
+    return {
+      packageDirectory: dirname(manifestPath),
+      tsxEntryUrl: pathToFileURL(packageRequire.resolve('tsx')).href,
     }
   }
 

--- a/apps/desktop/src/main/memory/memory-core-supervisor.ts
+++ b/apps/desktop/src/main/memory/memory-core-supervisor.ts
@@ -1,8 +1,7 @@
 import { randomBytes } from 'node:crypto'
 import { mkdir } from 'node:fs/promises'
 import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { join } from 'node:path'
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 
 import { app } from 'electron'
@@ -67,7 +66,7 @@ export class MemoryCoreSupervisor {
     }
 
     const apiKey = randomBytes(24).toString('base64url')
-    const { packageDirectory, tsxEntryUrl } = this.resolvePackage()
+    const entryPath = this.resolveEntry()
     await mkdir(this.dataDirectory, { recursive: true })
     // 数据目录收进应用数据(KS 的 knowledge/ 同款约定):不设 TDAI_DATA_DIR 时
     // MemoryCore 默认落 ~/.memory-tencentdb/,卸载/清数据会留残骸。
@@ -77,12 +76,9 @@ export class MemoryCoreSupervisor {
     await mkdir(logDirectory, { recursive: true })
 
     const command = app.isPackaged ? process.execPath : (process.env.NXCORE_MEMORY_NODE ?? 'node')
-    // Windows + Node 22 的组合下:--import 必须是 file:// URL,而主入口必须是
-    // 正斜杠路径(file:// 会被误判为 CJS 相对路径,反斜杠会被判为 URL scheme)。
-    const serverEntry = join(packageDirectory, 'src', 'gateway', 'server.ts').replace(/\\/g, '/')
     const child = spawn(
       command,
-      ['--import', tsxEntryUrl, serverEntry],
+      [entryPath],
       {
         cwd: dataDir,
         env: {
@@ -201,24 +197,13 @@ export class MemoryCoreSupervisor {
     throw new Error(`MemoryCore did not become ready within ${STARTUP_TIMEOUT_MS}ms`)
   }
 
-  private resolvePackage(): { packageDirectory: string; tsxEntryUrl: string } {
+  private resolveEntry(): string {
     const override = process.env.NXCORE_MEMORY_CORE_DIR?.trim()
-    if (override) {
-      const packageRequire = createRequire(join(override, 'package.json'))
-      return { packageDirectory: override, tsxEntryUrl: pathToFileURL(packageRequire.resolve('tsx')).href }
-    }
-    if (app.isPackaged) {
-      const packageDirectory = join(process.resourcesPath, 'memory-core')
-      const packageRequire = createRequire(join(packageDirectory, 'package.json'))
-      return { packageDirectory, tsxEntryUrl: pathToFileURL(packageRequire.resolve('tsx')).href }
-    }
+    if (override) return join(override, 'bin', 'memory-gateway.mjs')
     // dev:从 apps/desktop 的 node_modules 解析 git 依赖安装的 memory-core 包。
     // 包的 exports 只放行了 ./bin/*,所以用 bin 入口定位包根目录。
     const baseRequire = createRequire(join(app.getAppPath(), 'package.json'))
-    const binPath = baseRequire.resolve(`${PACKAGE_NAME}/bin/memory-gateway.mjs`)
-    const packageDirectory = dirname(dirname(binPath))
-    const packageRequire = createRequire(binPath)
-    return { packageDirectory, tsxEntryUrl: pathToFileURL(packageRequire.resolve('tsx')).href }
+    return baseRequire.resolve(`${PACKAGE_NAME}/bin/memory-gateway.mjs`)
   }
 
   private killChild(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   app-builder-lib>@electron/get: 3.1.0
+  better-sqlite3: 13.0.3
 
 patchedDependencies:
   pi-mcp-adapter@2.26.1: 10c2c1734b5cc6e2dfea25e01802255613a59f22b5e0940b4607f7f96c716d46
@@ -91,6 +92,9 @@ importers:
       axios:
         specifier: ^1.19.0
         version: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      better-sqlite3:
+        specifier: 13.0.3
+        version: 13.0.3
       d3-force:
         specifier: ^3.0.0
         version: 3.0.0
@@ -258,7 +262,7 @@ importers:
         specifier: ^1.19.0
         version: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       better-sqlite3:
-        specifier: ^13.0.3
+        specifier: 13.0.3
         version: 13.0.3
       drizzle-orm:
         specifier: ^0.45.2
@@ -2367,7 +2371,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.6.0':
     resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
@@ -2381,14 +2384,12 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.6.0':
     resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.6.0':
     resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
@@ -4109,9 +4110,6 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
-
   better-sqlite3@13.0.3:
     resolution: {integrity: sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==}
     engines: {node: '>=22'}
@@ -4126,14 +4124,8 @@ packages:
   binary@0.3.0:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
 
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
   bl@4.0.1:
     resolution: {integrity: sha512-FL/TdvchukRCuWVxT0YMO/7+L5TNeNrVFvRU2IY63aUyv9mpt8splf2NEr6qXtPo5fya5a66YohQKvGNmLrWNA==}
-
-  bl@4.0.3:
-    resolution: {integrity: sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==}
 
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
@@ -4305,9 +4297,6 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
-
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -4552,10 +4541,6 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
-
   deepmerge-ts@7.1.6:
     resolution: {integrity: sha512-gQhL1ksGBLQbHeAo47YU6cs2ahd3Pv+8PFYoWogNZbQnNwQyOh9Ad5kbeHFiWwbKdeWQJ5Z7Y7mwb9ew2hXBLw==}
     engines: {node: '>=16.0.0'}
@@ -4708,7 +4693,7 @@ packages:
       '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
-      better-sqlite3: '>=7'
+      better-sqlite3: 13.0.3
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
@@ -4800,7 +4785,7 @@ packages:
       '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
-      better-sqlite3: '>=7'
+      better-sqlite3: 13.0.3
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
@@ -5108,10 +5093,6 @@ packages:
     resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
     engines: {node: '>=8.3.0'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -5214,9 +5195,6 @@ packages:
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
@@ -5374,9 +5352,6 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -6290,9 +6265,6 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -6362,9 +6334,6 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -6372,10 +6341,6 @@ packages:
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
-
-  node-abi@3.94.0:
-    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
-    engines: {node: '>=10'}
 
   node-abi@4.33.0:
     resolution: {integrity: sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==}
@@ -6751,12 +6716,6 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6915,10 +6874,6 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -7435,12 +7390,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   simple-git@3.36.0:
     resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
@@ -7595,10 +7544,6 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
@@ -7648,15 +7593,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tar-fs@2.1.5:
-    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
-
   tar-stream@2.1.2:
     resolution: {integrity: sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==}
-
-  tar-stream@2.1.4:
-    resolution: {integrity: sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==}
-    engines: {node: '>=6'}
 
   tar@7.5.22:
     resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
@@ -11229,11 +11167,11 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/sdk-node': 0.219.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       ai: 6.0.255(zod@4.4.3)
-      better-sqlite3: 11.10.0
+      better-sqlite3: 13.0.3
       crc-32: 1.2.2
       dayjs: 1.11.21
       dotenv: 16.4.5
-      drizzle-orm: 0.44.0(@opentelemetry/api@1.9.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@11.10.0)
+      drizzle-orm: 0.44.0(@opentelemetry/api@1.9.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.3)
       graphology: 0.26.0(graphology-types@0.24.8)
       graphology-communities-louvain: 2.0.2(graphology-types@0.24.8)
       hono: 4.13.2
@@ -12142,11 +12080,6 @@ snapshots:
       tweetnacl: 0.14.5
     optional: true
 
-  better-sqlite3@11.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
   better-sqlite3@13.0.3:
     dependencies:
       node-addon-api: 8.9.2
@@ -12160,18 +12093,8 @@ snapshots:
       buffers: 0.1.1
       chainsaw: 0.1.0
 
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
   bl@4.0.1:
     dependencies:
-      readable-stream: 3.6.2
-
-  bl@4.0.3:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
       readable-stream: 3.6.2
 
   bluebird@3.4.7: {}
@@ -12366,8 +12289,6 @@ snapshots:
     dependencies:
       readdirp: 5.1.1
     optional: true
-
-  chownr@1.1.4: {}
 
   chownr@3.0.0: {}
 
@@ -12595,8 +12516,6 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  deep-extend@0.6.0: {}
-
   deepmerge-ts@7.1.6: {}
 
   default-browser-id@5.0.1: {}
@@ -12646,7 +12565,8 @@ snapshots:
 
   destroy@1.2.0: {}
 
-  detect-libc@2.1.2: {}
+  detect-libc@2.1.2:
+    optional: true
 
   detect-node-es@1.1.0: {}
 
@@ -12727,11 +12647,11 @@ snapshots:
       esbuild: 0.25.5
       tsx: 4.23.12
 
-  drizzle-orm@0.44.0(@opentelemetry/api@1.9.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@11.10.0):
+  drizzle-orm@0.44.0(@opentelemetry/api@1.9.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.3):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 9.6.0
-      better-sqlite3: 11.10.0
+      better-sqlite3: 13.0.3
 
   drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@9.6.0)(better-sqlite3@13.0.3):
     optionalDependencies:
@@ -13077,8 +12997,6 @@ snapshots:
       unzipper: 0.10.11
       uuid: 8.3.0
 
-  expand-template@2.0.3: {}
-
   expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
@@ -13231,8 +13149,6 @@ snapshots:
       web-streams-polyfill: 3.3.3
 
   fflate@0.8.3: {}
-
-  file-uri-to-path@1.0.0: {}
 
   filelist@1.0.6:
     dependencies:
@@ -13434,8 +13350,6 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
     optional: true
-
-  github-from-package@0.0.0: {}
 
   glob@13.0.6:
     dependencies:
@@ -13853,7 +13767,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.4: {}
+  ini@1.3.4:
+    optional: true
 
   ini@5.0.0:
     optional: true
@@ -14660,8 +14575,6 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mkdirp-classic@0.5.3: {}
-
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -14715,15 +14628,9 @@ snapshots:
 
   nanoid@5.1.16: {}
 
-  napi-build-utils@2.0.0: {}
-
   negotiator@1.0.0: {}
 
   netmask@2.1.1: {}
-
-  node-abi@3.94.0:
-    dependencies:
-      semver: 7.8.5
 
   node-abi@4.33.0:
     dependencies:
@@ -15164,21 +15071,6 @@ snapshots:
       commander: 9.5.0
     optional: true
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.94.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.5
-      tunnel-agent: 0.6.0
-
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -15379,13 +15271,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       unpipe: 1.0.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.4
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -15952,14 +15837,6 @@ snapshots:
   signal-exit@4.1.0:
     optional: true
 
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
   simple-git@3.36.0(supports-color@8.1.1):
     dependencies:
       '@kwsites/file-exists': 1.1.1(supports-color@8.1.1)
@@ -16121,8 +15998,6 @@ snapshots:
       ansi-regex: 6.3.0
     optional: true
 
-  strip-json-comments@2.0.1: {}
-
   strip-json-comments@5.0.3: {}
 
   strnum@1.0.5:
@@ -16180,24 +16055,9 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tar-fs@2.1.5:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.1.4
-
   tar-stream@2.1.2:
     dependencies:
       bl: 4.0.1
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
-  tar-stream@2.1.4:
-    dependencies:
-      bl: 4.0.3
       end-of-stream: 1.4.5
       fs-constants: 1.0.0
       inherits: 2.0.4
@@ -16341,6 +16201,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   tunnel@0.0.6:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 
 overrides:
   "app-builder-lib>@electron/get": "3.1.0"
+  "better-sqlite3": "13.0.3"
 
 allowBuilds:
   '@google/genai': true


### PR DESCRIPTION
## 改动

- 修复打包态 MemoryCore 与 Knowledge Service 的运行入口，并只纳入两套服务必需的 TypeScript 源码
- 解包并指定 esbuild 平台二进制，将 better-sqlite3 统一到兼容 Electron 39 的 13.0.3
- Release 构建内置 OpenConnector 与 oo CLI；Nango 在尚未支持的打包态静默标记为禁用
- 放宽误伤运行时源码的发布审计，同时新增必需入口、原生模块、oo CLI 和 Windows 冷启动健康检查
- 增加 NXCORE_DATA_DIR，使 CI 与本地可以在真正干净的数据目录验证首次启动

## 验证

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `actionlint .github/workflows/release-desktop.yml`
- Windows 目录包在全新 E 盘 profile 首次启动和再次启动：Gateway、Memory、Knowledge 均返回 200
- NSIS 安装器静默安装到全新 E 盘目录后启动：主进程响应，三个健康检查均通过，服务错误为 0

## 发布说明

Windows 安装器与 macOS 产物仍未配置正式代码签名/公证；功能自包含，但首次下载可能触发 SmartScreen 或 Gatekeeper 提示。