### PR TITLE
修复 Windows 发布冷启动脚本语法

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -300,7 +300,7 @@ jobs:
           } finally {
             if (-not $app.HasExited) {
               $null = $app.CloseMainWindow()
-              if (-not $app.WaitForExit(10_000)) { & taskkill.exe /PID $app.Id /T /F | Out-Null }
+              if (-not $app.WaitForExit(10000)) { & taskkill.exe /PID $app.Id /T /F | Out-Null }
             }
           }
 


### PR DESCRIPTION
修复 Release 工作流中 PowerShell 不支持的数字分隔符写法。将 WaitForExit(10_000) 改为 WaitForExit(10000)，避免安装包冷启动校验在启动应用前发生 ParserError。已通过 Windows PowerShell 语法解析校验。