### PR TITLE
fix: 选区重写链路三处修复（skills 挂载 / preflight 误判 / operation 校验）+ Room context 接口恢复

### DIFF
--- a/apps/desktop/src/renderer/src/components/context-room/ported/components/detail-editor/documentCursorCompletionAgent.ts
+++ b/apps/desktop/src/renderer/src/components/context-room/ported/components/detail-editor/documentCursorCompletionAgent.ts
@@ -418,6 +418,7 @@ export async function streamDocumentCursorCompletion(
       captureMemory: false,
       recallMemory: false,
       toolsEnabled: false,
+      context: { selectedRoomId: input.roomId },
     })
     runId = run.id
     if (options.signal.aborted) {

--- a/apps/desktop/src/renderer/src/components/context-room/ported/components/detail-editor/selectionRewriteAgent.ts
+++ b/apps/desktop/src/renderer/src/components/context-room/ported/components/detail-editor/selectionRewriteAgent.ts
@@ -166,6 +166,7 @@ export async function streamSelectionRewrite(
       captureMemory: false,
       recallMemory: false,
       toolsEnabled: false,
+      context: { selectedRoomId: input.roomId },
     })
     runId = run.id
     if (options.signal.aborted) {

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -185,7 +185,7 @@ export interface PiRuntimeConfig {
   systemPrompt?: string;
   runtimeRole?: "user-facing" | "internal";
   skillsEnabled?: boolean;
-  additionalSkillPaths?: string[];
+  skillPrompts?: Record<string, string>;
   includeBashTool?: boolean;
   maxToolCallsPerRun?: number;
   /** Pi 内置工具白名单；缺省启用全部，NXCORE_PI_TOOLS（逗号分隔）收窄。 */

--- a/apps/gateway/src/modules/agent/runtime-factory.ts
+++ b/apps/gateway/src/modules/agent/runtime-factory.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { FakeAgentRuntime } from "@nxcore/agent-runtime/testing";
 import { PiAgentRuntime, type PiAgentRuntimeTool } from "@nxcore/agent-runtime-pi";
@@ -55,12 +54,6 @@ function builtin(id: (typeof BUILTIN_AGENT_IDS)[keyof typeof BUILTIN_AGENT_IDS])
   return loadBuiltinAgentBundle(bundledAgentDefinitionsDir(), id);
 }
 
-function builtinSkillPaths(bundle: ReturnType<typeof builtin>): string[] {
-  return bundle.skills
-    .map((skill) => join(bundle.directory, skill))
-    .filter((path) => existsSync(path));
-}
-
 function withAgentDirectories(
   config: GatewayConfig,
   agentId: string,
@@ -90,7 +83,7 @@ export function createAgentRuntime(
     ...withAgentDirectories(config, BUILTIN_AGENT_IDS.primary, config.pi),
     runtimeRole: "user-facing",
     skillsEnabled: true,
-    additionalSkillPaths: builtinSkillPaths(bundle),
+    skillPrompts: bundle.skillPrompts,
     systemPrompt: bundle.systemPrompt,
   }, {
     tools: [
@@ -126,7 +119,7 @@ export function createConnectorSyncAgentRuntime(
       maxToolCallsPerRun: 128,
       runtimeRole: "internal",
       skillsEnabled: true,
-      additionalSkillPaths: builtinSkillPaths(bundle),
+      skillPrompts: bundle.skillPrompts,
     }),
     systemPrompt: bundle.systemPrompt,
   }, {
@@ -143,7 +136,7 @@ export function createBackgroundAgentRuntime(config: GatewayConfig): AgentRuntim
     ...withAgentDirectories(config, BUILTIN_AGENT_IDS.transcriptionSummary, pi),
     runtimeRole: "internal",
     skillsEnabled: true,
-    additionalSkillPaths: builtinSkillPaths(bundle),
+    skillPrompts: bundle.skillPrompts,
     systemPrompt: bundle.systemPrompt,
   });
 }
@@ -190,7 +183,7 @@ export function createCursorCompletionRuntime(config: GatewayConfig): AgentRunti
     ...withAgentDirectories(config, BUILTIN_AGENT_IDS.cursorCompletion, config.cursorCompletionPi),
     runtimeRole: "internal",
     skillsEnabled: true,
-    additionalSkillPaths: builtinSkillPaths(bundle),
+    skillPrompts: bundle.skillPrompts,
     systemPrompt: bundle.systemPrompt,
   });
 }

--- a/apps/gateway/src/modules/agent/service.ts
+++ b/apps/gateway/src/modules/agent/service.ts
@@ -878,10 +878,12 @@ export class AgentService {
 
     // Selection and clarification controls are driven by completed tool events.
     // Emit those preflights deterministically instead of relying on model behavior.
-    const documentTopic = !runRoomId
+    // toolsEnabled=false 的运行是内部纯文本调用（选区重写/续写），不触发 UI 预检。
+    const interactiveRun = input.toolsEnabled !== false;
+    const documentTopic = interactiveRun && !runRoomId
       ? ambiguousDocumentTopic(input.prompt)
       : null;
-    const preflightTool = !runRoomId && requestsWorkspaceDocument(input.prompt)
+    const preflightTool = interactiveRun && !runRoomId && requestsWorkspaceDocument(input.prompt)
       ? {
           name: "context_room_list",
           result: { rooms, selectionRequired: true },

--- a/apps/gateway/src/modules/knowledge/llm.ts
+++ b/apps/gateway/src/modules/knowledge/llm.ts
@@ -94,6 +94,25 @@ export class KnowledgeLlm {
     return this.chatJson("entity-extraction", prompt, parseExtractionResponse);
   }
 
+  /** Room 当前文档集合 → 只读的详情投影，不参与资料归属判决。 */
+  async summarizeRoom(
+    roomTitle: string,
+    sourceDocuments: Array<{ title: string; markdown: string }>,
+  ): Promise<RoomContextResult> {
+    const prompt = [
+      `Room：${roomTitle}`,
+      `今天日期：${new Date().toISOString().slice(0, 10)}`,
+      "",
+      ...sourceDocuments.slice(0, 12).flatMap((document, index) => [
+        `--- 资料 ${index + 1}：《${document.title}》 ---`,
+        document.markdown.slice(0, 6_000),
+        "",
+      ]),
+      "请给出 Room 上下文 JSON。",
+    ].join("\n").slice(0, 36_000);
+    return this.chatJson("room-context", prompt, parseRoomContextResponse);
+  }
+
   /** 模糊带同一性判定（4.2/4.5）：双方是否同一实体。 */
   async judgeEntityIdentity(a: EntityIdentityInput, b: EntityIdentityInput): Promise<JudgeResult> {
     const prompt = [

--- a/apps/gateway/src/modules/knowledge/routes.ts
+++ b/apps/gateway/src/modules/knowledge/routes.ts
@@ -50,6 +50,37 @@ const MaterialDto = Type.Object({
   ingested: Type.Boolean(),
 });
 
+const RoomContextDto = Type.Object({
+  roomId: Type.String(),
+  generatedAt: Type.String(),
+  sourceDocuments: Type.Array(Type.Object({
+    documentId: Type.String(),
+    title: Type.String(),
+    version: Type.Integer(),
+    updatedAt: Type.String(),
+  })),
+  overview: Type.String(),
+  status: Type.String(),
+  nextSteps: Type.Array(Type.String()),
+  entities: Type.Array(Type.Object({
+    name: Type.String(),
+    kind: Type.String(),
+    description: Type.String(),
+  })),
+  actionItems: Type.Array(Type.Object({
+    title: Type.String(),
+    owner: Type.Union([Type.String(), Type.Null()]),
+    dueDate: Type.Union([Type.String(), Type.Null()]),
+    sourceTitle: Type.String(),
+  })),
+  meetings: Type.Array(Type.Object({
+    title: Type.String(),
+    when: Type.String(),
+    participants: Type.Array(Type.String()),
+    sourceTitle: Type.String(),
+  })),
+});
+
 const EntrySignalsSchema = Type.Object({
   sourceTag: Type.Optional(Type.String({ maxLength: 200 })),
   threadId: Type.Optional(Type.String({ maxLength: 200 })),
@@ -494,6 +525,18 @@ export function knowledgeRoutes(service: KnowledgeService): FastifyPluginAsyncTy
           updatedAt: iso(material.updatedAt),
         })),
       }),
+    );
+
+    app.get(
+      "/v1/knowledge/rooms/:id/context",
+      {
+        schema: {
+          tags: ["knowledge"],
+          params: RoomIdParams,
+          response: { 200: RoomContextDto },
+        },
+      },
+      async (request) => service.roomContext(request.params.id),
     );
 
     app.get(

--- a/apps/gateway/src/modules/knowledge/service.ts
+++ b/apps/gateway/src/modules/knowledge/service.ts
@@ -34,7 +34,9 @@ import { convertUploadedFile } from "./file-convert.js";
 import {
   KnowledgeLlm,
   type RegisterResult,
+  type RoomContextResult,
 } from "./llm.js";
+import { tiptapToMarkdown } from "./tiptap-markdown.js";
 import { OpenAiCompletionAgentRuntime } from "../agent/openai-completion-runtime.js";
 import { AgentResolver, BUILTIN_AGENT_IDS } from "../agent/resolver.js";
 import { loadBuiltinAgentBundle } from "../agent/builtin-bundles.js";
@@ -379,6 +381,7 @@ export class KnowledgeService {
   private readonly entityRegistry: EntityRegistry;
   private readonly router: KnowledgeRouter;
   private readonly llm: KnowledgeLlm | null;
+  private readonly roomContextCache = new Map<string, { key: string; value: RoomContextSummary }>();
   private readonly ownedAgentResolver: AgentResolver | null;
   /** 字节与登记表的唯一所有者是 modules/files（U9）；此处仅编排路由/ingest。 */
   private readonly files: FilesService;
@@ -2465,4 +2468,81 @@ export class KnowledgeService {
       ingested: ingested.has(document.id),
     }));
   }
+
+  /** Room 详情投影：资料集合是事实源，LLM 只负责汇总，不直接改用户 Room 数据。 */
+  async roomContext(roomId: string): Promise<RoomContextSummary> {
+    const rows = this.db.select({ document: documents })
+      .from(roomDocumentLinks)
+      .innerJoin(documents, eq(roomDocumentLinks.documentId, documents.id))
+      .where(and(eq(roomDocumentLinks.roomId, roomId), isNull(documents.deletedAt)))
+      .orderBy(desc(documents.updatedAt))
+      .all()
+      .filter(({ document }) => document.status === "active");
+    const sourceDocuments = rows.map(({ document }) => ({
+      documentId: document.id,
+      title: document.title,
+      version: document.version,
+      updatedAt: document.updatedAt.toISOString(),
+    }));
+    const key = sourceDocuments.map((item) => `${item.documentId}:${item.version}`).join(" ");
+    const cached = this.roomContextCache.get(roomId);
+    if (cached?.key === key) return cached.value;
+
+    const fallbackStatus = sourceDocuments.length > 0
+      ? `已收录 ${sourceDocuments.length} 份文档，最新资料《${sourceDocuments[0]!.title}》已更新。`
+      : "";
+    let context: RoomContextResult = {
+      overview: fallbackStatus,
+      status: fallbackStatus,
+      nextSteps: [],
+      entities: [],
+      actionItems: [],
+      meetings: [],
+    };
+    let cacheable = !this.llm || rows.length === 0;
+    if (this.llm && rows.length > 0) {
+      const room = this.db.select({ title: rooms.title }).from(rooms).where(eq(rooms.id, roomId)).get();
+      try {
+        const generated = await this.llm.summarizeRoom(
+          room?.title ?? roomId,
+          rows.map(({ document }) => ({
+            title: document.title,
+            markdown: tiptapToMarkdown(document.contentJson as TiptapJsonContent),
+          })),
+        );
+        const sourceTitles = new Set(sourceDocuments.map((document) => document.title));
+        context = {
+          ...generated,
+          status: generated.status || fallbackStatus,
+          actionItems: generated.actionItems.filter((item) => sourceTitles.has(item.sourceTitle)),
+          meetings: generated.meetings.filter((item) => sourceTitles.has(item.sourceTitle)),
+        };
+        cacheable = true;
+      } catch (error) {
+        this.logger.warn(
+          { event: "knowledge.room_context.failed", roomId, error: error instanceof Error ? error.message : String(error) },
+          "Room context refresh failed; using document fallback",
+        );
+      }
+    }
+    const value: RoomContextSummary = {
+      roomId,
+      generatedAt: new Date().toISOString(),
+      sourceDocuments,
+      ...context,
+    };
+    if (cacheable) this.roomContextCache.set(roomId, { key, value });
+    return value;
+  }
+}
+
+export interface RoomContextSummary extends RoomContextResult {
+  roomId: string;
+  generatedAt: string;
+  sourceDocuments: Array<{
+    documentId: string;
+    title: string;
+    version: number;
+    updatedAt: string;
+  }>;
 }

--- a/packages/agent-runtime-pi/src/index.ts
+++ b/packages/agent-runtime-pi/src/index.ts
@@ -103,8 +103,13 @@ export interface PiAgentRuntimeConfig {
   /** Optional per-agent metadata used by the Gateway resolver. */
   runtimeId?: string;
   runtimeRole?: "user-facing" | "internal";
+  /** 启用时将 skillPrompts 内联进系统提示词（无 read 工具也能生效）。 */
   skillsEnabled?: boolean;
-  additionalSkillPaths?: string[];
+  /**
+   * Skill 名 → SKILL.md 全文。内联注入系统提示词；additionalSkillPaths 的
+   * 文件发现机制依赖 read 工具，toolsEnabled=false 的运行（如选区重写）不可用。
+   */
+  skillPrompts?: Record<string, string>;
   systemPrompt?: string;
   includeBashTool?: boolean;
   maxToolCallsPerRun?: number;
@@ -532,15 +537,24 @@ export class PiAgentRuntime implements AgentRuntime {
       ...(extensionFactories.length > 0 ? { extensionFactories } : {}),
       systemPromptOverride: () => {
         const lines = [
-          "你是 NxCore 桌面工作区中的 AI 助手。",
-          "回答应准确、简洁，并使用与用户相同的语言。",
-          "聊天回复使用自然、简洁的纯文本格式；不要使用 Markdown 标题符、粗体或斜体标记、反引号、代码围栏、表格或不常用装饰符号。需要列举时只使用普通数字列表或短句。文档正文仍按文档工具要求使用 Markdown。",
-          "当用户使用中文时，聊天回复、文档标题和文档正文必须使用简体中文及中国大陆常用措辞；除非用户明确要求，否则不要使用繁体中文。",
+          ...(this.config.systemPrompt ? [this.config.systemPrompt] : [
+            "你是 NxCore 桌面工作区中的 AI 助手。",
+            "回答应准确、简洁，并使用与用户相同的语言。",
+            "聊天回复使用自然、简洁的纯文本格式；不要使用 Markdown 标题符、粗体或斜体标记、反引号、代码围栏、表格或不常用装饰符号。需要列举时只使用普通数字列表或短句。文档正文仍按文档工具要求使用 Markdown。",
+            "当用户使用中文时，聊天回复、文档标题和文档正文必须使用简体中文及中国大陆常用措辞；除非用户明确要求，否则不要使用繁体中文。",
+          ]),
           "使用工具时，过程说明只补充工具行本身无法表达的信息，例如调用原因、关键发现、判断或对用户的影响；不要复述工具名称、执行状态、参数或下一项工具。没有新增信息时直接继续调用工具，不要强制输出过渡句。过程说明必须基于真实结果，不能臆测成功或输出冗长执行日志。",
           "最后一项工具完成后，必须给出独立、完整的最终答复，简洁总结完成了什么、关键结果以及仍需用户处理的事项；不要把过程说明直接拼接成最终答复。",
           "检索结果不足时不要反复改写同义关键词搜索；最多补充检索一次，仍无有效内容时立即停止工具调用，明确说明未找到什么、因此无法可靠完成什么，以及用户需要提供什么。不得用模板或猜测替代缺失事实。",
           "新文档提交成功后，最终答复必须用 2 至 4 句总结文档目标、核心内容和完成结果；中文约 180 字以内，英文约 80 词以内，不得复述标题目录、正文段落或长列表。",
         ];
+        // 内置 Skill 全文内联：toolsEnabled=false 的运行（如选区重写）没有 read
+        // 工具，无法走 SDK 的"用 read 加载 SKILL.md"发现机制。
+        if (this.config.skillsEnabled !== false) {
+          for (const [name, prompt] of Object.entries(this.config.skillPrompts ?? {})) {
+            lines.push("", `<skill name="${name}">`, prompt, `</skill>`);
+          }
+        }
         const responseLanguage = context.current?.responseLanguage?.trim();
         if (responseLanguage) {
           lines.push(


### PR DESCRIPTION
## 概要

修复编辑器选区重写（selection-rewrite）全链路三处断裂，并恢复被误删的 Room context 接口：

1. **恢复 Room context 接口**（`4a41acc`）：`5c624de` 调和合并时误删了 Gateway 侧 `GET /v1/knowledge/rooms/:id/context` 路由、`KnowledgeService.roomContext()` 与 `KnowledgeLlm.summarizeRoom()`，但桌面端调用链仍在，打开 Context Room 即 404。按 `fc6351b` 原实现恢复。

2. **PiAgentRuntime 真正挂载 bundle 的 systemPrompt 与 skills**（`8381902`）：runtime-factory 传入的 `skillsEnabled`/`additionalSkillPaths`/`systemPrompt` 从未被消费（`noSkills: true` + 硬编码 systemPromptOverride），内置 Skill 实际全部不可见。改为将 SKILL.md 全文内联注入系统提示词（内联是必须的：`toolsEnabled: false` 的运行没有 read 工具，无法走 SDK 的文件发现机制）。

3. **toolsEnabled=false 不再触发文档创建预检**（`34f931b`）：重写 prompt「重写文档」命中 `requestsWorkspaceDocument` 的 `/写.{0,32}文档/`，preflight 合成 `context_room_list` 直接 run.completed，模型从未被调用（日志实证：run 创建 3ms 即被删）。

4. **选区重写/光标补全 run 携带 selectedRoomId**（`0f5b61a`）：run 未传 `context.selectedRoomId` 导致 `execution.roomId` 为 null，重写完成后 `POST /v1/document-operations` 被 `validateDocumentOperationContext` 拒绝（agent_operation_context_invalid）。

## 验证

- gateway + agent-runtime-pi + desktop `tsc --noEmit` 通过
- gateway 测试 413/413 全部通过（合并最新 main 后，main 侧已修复此前 11 个既有失败）
- 实测选区重写全链路走通（流式输出 → 替换文本应用成功）

🤖 Generated with [Claude Code](https://claude.com/claude-code)