### PR TITLE
修复首次启动时 MemoryCore 被禁用并支持分支 CI

### DIFF
--- a/.github/workflows/app-windows-ci.yml
+++ b/.github/workflows/app-windows-ci.yml
@@ -3,7 +3,6 @@ name: Windows app CI
 on:
   pull_request:
   push:
-    branches: [main]
 
 permissions:
   contents: read

--- a/apps/desktop/src/main/gateway/files-gateway-bridge.test.ts
+++ b/apps/desktop/src/main/gateway/files-gateway-bridge.test.ts
@@ -41,7 +41,7 @@ describe('collectImportCandidates', () => {
   })
 
   it('ignores dependency and build directories during a one-time directory scan', async () => {
-    const directory = await mkdtemp(join('/tmp', 'everroom-import-ignored-'))
+    const directory = await mkdtemp(join(tmpdir(), 'everroom-import-ignored-'))
     temporaryDirectories.push(directory)
     await mkdir(join(directory, 'node_modules', 'dependency'), { recursive: true })
     await mkdir(join(directory, 'build'), { recursive: true })
@@ -56,7 +56,7 @@ describe('collectImportCandidates', () => {
   })
 
   it('deduplicates overlapping and missing selections', async () => {
-    const directory = await mkdtemp(join('/tmp', 'everroom-import-duplicate-'))
+    const directory = await mkdtemp(join(tmpdir(), 'everroom-import-duplicate-'))
     temporaryDirectories.push(directory)
     const filePath = join(directory, 'notes.md')
     await writeFile(filePath, '# notes')
@@ -74,7 +74,7 @@ describe('collectImportCandidates', () => {
 
 describe('FilesGatewayBridge.importPathsOnce', () => {
   it('filters with gateway capabilities and imports through the unified manual path', async () => {
-    const directory = await mkdtemp(join('/tmp', 'everroom-import-once-'))
+    const directory = await mkdtemp(join(tmpdir(), 'everroom-import-once-'))
     temporaryDirectories.push(directory)
     await mkdir(join(directory, 'notes'))
     await writeFile(join(directory, 'notes', 'kept.md'), '# kept')

--- a/apps/gateway/src/server/create-server.ts
+++ b/apps/gateway/src/server/create-server.ts
@@ -190,7 +190,7 @@ export async function createServer(config: GatewayConfig, overrides: ServerOverr
   await app.register(websocket);
   await app.register(auth, { token: config.authToken });
   await app.register(systemRoutes);
-  const memoryService = new MemoryService(config.pi?.memory ?? null, app.log, { db, dataDir: config.dataDir });
+  const memoryService = new MemoryService(config.memory, app.log, { db, dataDir: config.dataDir });
   const contextRoomService = new ContextRoomService(db);
   const documentEventBroker = new DocumentEventBroker();
   const documentOperationService = new DocumentOperationService(db, documentEventBroker);

--- a/apps/gateway/tests/server.test.ts
+++ b/apps/gateway/tests/server.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentRun, AgentSession, TrustedMcpSession } from "@nxcore/agent-contract";
 import type { GatewayConfig } from "../src/config.js";
 import { createServer } from "../src/server/create-server.js";
@@ -37,6 +37,7 @@ async function testConfig(): Promise<GatewayConfig> {
 }
 
 afterEach(async () => {
+  vi.unstubAllGlobals();
   await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
 });
 
@@ -64,6 +65,37 @@ describe("gateway server", () => {
 
     expect(unauthorized.statusCode).toBe(401);
     expect(authorized.statusCode).toBe(200);
+  });
+
+  it("keeps memory routes enabled without a Pi runtime", async () => {
+    const config = await testConfig();
+    config.memory = {
+      baseUrl: "http://127.0.0.1:8420",
+      apiKey: "memory-key",
+      serviceId: "everroom",
+      teamId: "everroom",
+      agentId: "pi-agent",
+      userId: "local-user",
+      recallLimit: 5,
+      charBudget: 2_000,
+    };
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      code: 0,
+      message: "ok",
+      data: { items: [], total: 0 },
+    }), { headers: { "content-type": "application/json" } })));
+    const app = await createServer(config);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/memory/atomic?limit=1&offset=0",
+      headers: { authorization: `Bearer ${config.authToken}` },
+    });
+    await app.close();
+
+    expect(config.pi).toBeNull();
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ items: [], total: 0 });
   });
 
   it("serves persisted perception and diary settings with local visual nodes", async () => {


### PR DESCRIPTION
## 变更说明

- 修复首次安装默认使用 fake Agent 时，独立 MemoryCore 配置被错误丢弃的问题
- 新增 `pi = null` 场景的 MemoryCore 路由回归测试
- Windows CI 改为支持任意分支 push，后续可直接在测试分支验证，无需反复创建 PR
- 修复桌面测试对 `/tmp` 的硬编码，改用系统跨平台临时目录

## 根因

Gateway 创建 `MemoryService` 时错误读取了 `config.pi?.memory`。首次安装默认 `config.pi = null`，即使 `config.memory` 已正确配置，也会把 MemoryCore 当作禁用。现在统一读取顶层 `config.memory`。

## 验证结果

- 分支 Windows CI 全部通过：类型检查、全量测试、Gateway 与桌面构建
- Gateway：52 个测试文件、421 项测试通过
- Desktop：83 个测试文件、392 项测试通过
- Windows 安装包在全新 E 盘用户数据目录冷启动通过
- MemoryCore、Knowledge、Gateway Ready、Memory Overview、Memory Atomic 健康检查均返回 200
- 打包内容审计通过，未包含禁止文件

## 发版影响

合并后可从 `main` 触发桌面发布工作流，生成新的 Windows x64 和 macOS arm64 预发布资产。