### PR TITLE
缩减普通 Windows CI 测试范围

### DIFF
--- a/.github/workflows/app-windows-ci.yml
+++ b/.github/workflows/app-windows-ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run tests
         id: tests
         continue-on-error: true
-        run: pnpm test
+        run: pnpm test:ci
 
       - name: Build gateway and desktop
         id: build

--- a/apps/gateway/tests/server.test.ts
+++ b/apps/gateway/tests/server.test.ts
@@ -65,7 +65,7 @@ describe("gateway server", () => {
 
     expect(unauthorized.statusCode).toBe(401);
     expect(authorized.statusCode).toBe(200);
-  });
+  }, 10_000);
 
   it("keeps memory routes enabled without a Pi runtime", async () => {
     const config = await testConfig();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "pnpm --filter @nxcore/gateway build && pnpm --filter @nxcore/desktop build",
     "typecheck": "pnpm --filter @nxcore/agent-contract typecheck && pnpm --filter @nxcore/connector-contract typecheck && pnpm --filter @nxcore/document-model typecheck && pnpm --filter @nxcore/reality-contract typecheck && pnpm --filter @nxcore/agent-runtime typecheck && pnpm --filter @nxcore/agent-runtime-pi typecheck && pnpm --filter @nxcore/gateway typecheck && pnpm --filter @nxcore/desktop typecheck",
     "test": "pnpm --filter @nxcore/document-model test && pnpm --filter @nxcore/agent-runtime test && pnpm --filter @nxcore/agent-runtime-pi test && pnpm --filter @nxcore/gateway test && pnpm --filter @nxcore/desktop test",
+    "test:ci": "pnpm --filter @nxcore/gateway exec vitest run tests/config.test.ts tests/server.test.ts && pnpm --filter @nxcore/desktop exec vitest run tests/gateway-supervisor.test.ts tests/memory-onboarding.test.ts tests/saas-client.test.ts",
     "package:mac": "pnpm --filter @nxcore/gateway build && pnpm --filter @nxcore/desktop package:mac"
   }
 }


### PR DESCRIPTION
## 变更说明

- 普通 Windows PR/分支 CI 从全量测试改为必要 smoke tests
- 新增根脚本 `pnpm test:ci`
- 保留 Gateway 配置、鉴权/Memory 路由、桌面 Gateway 启动、Memory 首次使用和 SaaS 客户端测试
- 保留完整类型检查和 Gateway/Desktop 构建
- Release 工作流仍保留全量测试、包内容审计和干净环境冷启动
- 包含现有分支中未推送的 Gateway 启动测试超时修正

## CI 时间优化

原先普通 CI 会执行所有工作区测试，Gateway 还会将 memory-doc-pipeline 单独再跑一轮。现在普通 CI 只运行 5 个必要测试文件，共 44 项测试；本地验证全部通过。

## 验证

- `pnpm test:ci`：Gateway 33 项、Desktop 11 项全部通过
- `git diff --check`：通过
- 未修改业务打包内容和 Release 工作流