### PR TITLE
ci: prevent Windows release test OOM

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -136,6 +136,7 @@ jobs:
     runs-on: windows-2025
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: "false"
+      NODE_OPTIONS: "--max-old-space-size=8192"
 
     steps:
       - name: Check out tagged commit


### PR DESCRIPTION
## What changed
- Raise the Windows Release job Node heap limit to 8 GiB.

## Why
The release precheck exhausted the default V8 heap while running the full Desktop Vitest suite on windows-2025; the tests passed locally and the runner failed with JavaScript heap out of memory.

## Validation
- git diff --check
- Change is limited to .github/workflows/release-desktop.yml

After merge, rerun the scheduled desktop release precheck before creating the release tag.