### PR TITLE
ci: skip tests in desktop release workflow

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -59,9 +59,6 @@ jobs:
       - name: Check types
         run: pnpm typecheck
 
-      - name: Run tests
-        run: pnpm test
-
       - name: Build app and bundled runtimes
         run: |
           pnpm build
@@ -177,9 +174,6 @@ jobs:
 
       - name: Check types
         run: pnpm typecheck
-
-      - name: Run tests
-        run: pnpm test
 
       - name: Build app and bundled runtimes
         run: |

--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -75,10 +75,6 @@ jobs:
         if: steps.candidate.outputs.pending == 'true'
         run: pnpm typecheck
 
-      - name: Run tests
-        if: steps.candidate.outputs.pending == 'true'
-        run: pnpm test
-
       - name: Build gateway and desktop
         if: steps.candidate.outputs.pending == 'true'
         run: pnpm build


### PR DESCRIPTION
## What changed\n- Remove pnpm test from the scheduled desktop release preflight.\n- Remove duplicate test steps from macOS and Windows desktop packaging jobs.\n\n## Why\nThe release workflow stalls/OOMs after the full suite completes on the Windows runner. Typecheck, build, package-content audit, and cold-start verification remain enabled.\n\n## Validation\n- git diff --check\n- Confirmed no pnpm test remains in the desktop release workflow files.