### PR TITLE
fix(desktop): 记忆引导完成后进入房间引导而非重开文件夹页

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -456,14 +456,14 @@ export function App() {
     <MemoryOnboardingGate activeStage={fullOnboardingStage} onMemoryGenerated={setGeneratedMemoryNotice} onFinished={() => {
       logOnboarding('memory-finished', {
         stage: fullOnboardingStageRef.current,
-        destination: 'folder',
+        destination: 'room',
       })
       setMemoryReady(true)
       if (fullOnboardingStageRef.current !== 'memory') return
       manualMemoryOnboardingRef.current = false
-      fullOnboardingStageRef.current = 'folder'
-      setFullOnboardingStage('folder')
-      setFolderOnboardingOpen(true)
+      fullOnboardingStageRef.current = 'room'
+      setFullOnboardingStage('room')
+      setFolderOnboardingOpen(false)
       setSuppressRoomOnboarding(false)
       setActivePage('settings')
     }} onNavigateStage={switchOnboardingStage}>

--- a/apps/desktop/src/renderer/src/components/onboarding/MemoryOnboardingGate.tsx
+++ b/apps/desktop/src/renderer/src/components/onboarding/MemoryOnboardingGate.tsx
@@ -232,11 +232,14 @@ export function MemoryOnboardingGate({ children, onFinished, onMemoryGenerated, 
     showResult: boolean,
   ) => {
     writeMemoryOnboardingMarker({ ...marker, status: 'completed', memoryId: item.id })
-    onMemoryGenerated?.(item)
     setPending(null)
     if (showResult) {
+      // 前台：直接在成功页展示生成结果；后台通知弹窗只留给用户已离开
+      // 等待页（gate 转 app 后仍在轮询）的完成场景，避免双展示。
       setGeneratedMemory({ item, sessionId: marker.sessionId, capturedAt: marker.capturedAt })
       setMode('success')
+    } else {
+      onMemoryGenerated?.(item)
     }
   }, [onMemoryGenerated])
 


### PR DESCRIPTION
## 问题

首次使用引导中，在记忆生成页面**等待第一条记忆生成完成后**点「继续」（或点「跳过」），会跳回已经完成过的文件夹设置页面；不等生成完成直接点「继续下一步」则正常进入房间引导。

## 原因

- 记忆引导成功页/跳过走 `finishOnboarding → onFinished`，而 `App.tsx` 的 onFinished 回调把目标 stage 设为 `folder`（`dde711a` 引入的回归），与 stage 顺序（folder→memory→room→ready）不符。
- 更糟的是会和文件夹页的 onClose（folder 未完成时回到 `memory`）形成 folder↔memory 循环，只有走「继续下一步」路径才能逃出。
- 附带问题：前台成功页展示结果后仍会触发 `onMemoryGenerated`，在房间引导上叠一个多余的「后台记忆已生成」弹窗。

## 修复

1. `App.tsx`：onFinished 目标从 `folder` 改回 `room`，行为与 `switchOnboardingStage('room')` 一致，房间引导表单由既有 effect 自动打开；`folderOnboardingOpen` 置为 `false`。
2. `MemoryOnboardingGate.tsx`：`completeWithMemory` 中 `onMemoryGenerated`（后台通知）只在前台不展示结果（后台轮询完成）时触发。

## 验证

- `tsc --noEmit` 通过。
- 建议实测三条路径：生成中点「继续下一步」、生成完成后点「继续」、以及「跳过」，均应进入房间引导。

🤖 Generated with [Claude Code](https://claude.com/claude-code)