### PR TITLE
修复 Windows 构建并缩短 CI

### DIFF
--- a/.github/workflows/app-windows-ci.yml
+++ b/.github/workflows/app-windows-ci.yml
@@ -44,4 +44,8 @@ jobs:
         run: pnpm test:ci
 
       - name: Build gateway and desktop
-        run: pnpm build
+        env:
+          SENTRY_AUTH_TOKEN: ""
+        run: |
+          pnpm --filter @nxcore/gateway build
+          pnpm --filter @nxcore/desktop exec electron-vite build

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -248,27 +248,9 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number,
-              event: 'APPROVE',
+              event: 'COMMENT',
               body: result.review,
             });
-
-            const { data: reviewed } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number,
-            });
-            if (reviewed.merged || reviewed.auto_merge) return;
-
-            await github.graphql(`
-              mutation EnableAutoMerge($pullRequestId: ID!) {
-                enablePullRequestAutoMerge(input: {
-                  pullRequestId: $pullRequestId,
-                  mergeMethod: MERGE
-                }) {
-                  pullRequest { autoMergeRequest { enabledAt } }
-                }
-              }
-            `, { pullRequestId: reviewed.node_id });
 
   issue:
     if: github.event_name == 'issues' && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)

--- a/apps/desktop/scripts/prepare-nango-runtime.mjs
+++ b/apps/desktop/scripts/prepare-nango-runtime.mjs
@@ -14,13 +14,16 @@ if (!existsSync(join(connectorRoot, 'package.json'))) {
   throw new Error(`Nango submodule is missing: ${connectorRoot}`)
 }
 
-const executable = (command) => process.platform === 'win32' ? `${command}.cmd` : command
-const run = (command, args, cwd) => execFileSync(executable(command), args, { cwd, stdio: 'inherit' })
+const run = (command, args, cwd) => execFileSync(command, args, {
+  cwd,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+})
 
 // CI checks out the submodule fresh without its own node_modules; the build
 // steps below (tsc, connect-ui vite build) need the connector's deps.
 if (!existsSync(join(connectorRoot, 'node_modules'))) {
-  run('npm', ['ci', '--no-audit', '--no-fund'], connectorRoot)
+  run('npm', ['ci', '--force', '--no-audit', '--no-fund'], connectorRoot)
 }
 
 // Build Nango once, then copy only its compiled packages and production dependencies.


### PR DESCRIPTION
修改内容

修复 Windows 下 npm 和 pnpm 命令解析。
允许 Nango 冻结安装解析包含其他平台预编译包的锁文件，完整发版构建已验证能够越过该步骤。
拉取请求的持续集成保留全量类型检查，五十一项关键烟测及 Gateway 和 Desktop 生产编译，不再重复耗时的完整运行时组装。
持续集成编译阶段显式禁用 Sentry 源映射上传。
AI Review 先发布审查评论，不再尝试代替真人批准或自动合并。main 分支仍要求一名真人审批。

验证结果

全量类型检查通过。
Gateway 三十九项关键测试全部通过，Desktop 十二项关键测试全部通过。
完整 Nango 构建成功越过原有的 Windows 平台错误。
精简后的 Gateway 和 Desktop 编译在本地通过，耗时约十几秒。
YAML 解析，Node 脚本语法和差异检查通过。