### PR TITLE
fix(knowledge): 接通 runtime config 到 Room 归类的两条 LLM 断链

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -34,6 +34,7 @@ import { cursorCompletionEnvFromConfig } from './gateway/cursor-completion-env'
 import { NangoSupervisor } from './gateway/nango-supervisor'
 import { MemoryGatewayBridge } from './gateway/memory-gateway-bridge'
 import { KnowledgeServiceSupervisor } from './knowledge/knowledge-supervisor'
+import { knowledgeServiceLlmEnv } from './knowledge/llm-env'
 import { MemoryCoreSupervisor } from './memory/memory-core-supervisor'
 import { embeddingFieldsFromConfig, memoryCoreEmbeddingEnv, memoryCoreEnvironment } from './memory/embedding-env'
 import type { KnowledgeAttachInput } from '../shared/knowledge'
@@ -1014,9 +1015,42 @@ async function syncManagedChildProcesses(snapshot: RuntimeConfigSnapshot): Promi
   const run = managedChildSyncQueue.then(async () => {
     await syncMemoryCoreEnvironment(snapshot)
     await syncCursorCompletionEnvironment(snapshot)
+    await syncKnowledgeServiceEnvironment(snapshot)
   })
   managedChildSyncQueue = run.catch(() => undefined)
   return run
+}
+
+/**
+ * Knowledge Service（Wiki 引擎）的 runtime config 同步：primary 三要素 →
+ * LLM_* 重启托管实例。KS 的 wiki ingest 依赖 LLM；.env 清空迁移 runtime
+ * config 后 spawn env 里 LLM_API_KEY 为空，ingest 会报「LLM apiKey 未配置」。
+ * 与 MemoryCore 同款 JSON 比较去重（配置没变不重启）。
+ */
+let knowledgeServiceAiEnvApplied: string | null = null
+
+async function syncKnowledgeServiceEnvironment(snapshot: RuntimeConfigSnapshot): Promise<void> {
+  try {
+    const supervisor = knowledgeServiceSupervisor
+    const initialConnection = supervisor?.getConnection() ?? null
+    if (!supervisor || !initialConnection) return
+    const nextEnv = knowledgeServiceLlmEnv(snapshot.config)
+    const nextJson = JSON.stringify(nextEnv)
+    if (nextJson === knowledgeServiceAiEnvApplied) return
+    if (initialConnection.managed) {
+      const restarted = await supervisor.restart(nextEnv)
+      if (restarted?.managed) {
+        knowledgeServiceAiEnvApplied = nextJson
+        console.info(`[knowledge] ai env ${nextEnv ? 'applied' : 'cleared'} (instance restarted)`)
+      } else {
+        // 复用模式（外部实例/残留进程占 8421）：env 未真正应用，不标记
+        // applied，下次 sync 重试。
+        console.warn('[knowledge] instance at 8421 is not managed by this app; ai env NOT applied (stray process?)')
+      }
+    }
+  } catch (error) {
+    console.error('[knowledge] failed to sync ai env:', error)
+  }
 }
 
 function registerConnectorHandlers(bridge: ConnectorGatewayBridge): void {
@@ -1934,6 +1968,9 @@ if (hasSingleInstanceLock) app.whenReady().then(async () => {
     }
     // Knowledge Service(Wiki)与 MemoryCore 同款托管;失败仅禁用 wiki 工具,不阻塞启动。
     knowledgeServiceSupervisor = new KnowledgeServiceSupervisor(dataDirectory)
+    // 冷启动先带 .env 透传起 KS（gateway 未起，runtime config 读不到）；
+    // gateway ready 后的 startup syncManagedChildProcesses 会按已存 primary
+    // 三要素重启注入 LLM_*（同 MemoryCore 的窗口收窄策略）。
     const knowledge = await knowledgeServiceSupervisor.start().catch((error) => {
       console.error('Managed Knowledge service failed to start; wiki tools stay disabled.', error)
       return null

--- a/apps/desktop/src/main/knowledge/knowledge-supervisor.ts
+++ b/apps/desktop/src/main/knowledge/knowledge-supervisor.ts
@@ -42,6 +42,11 @@ function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
 
+export interface KnowledgeServiceStartOptions {
+  /** runtime config 派生的 LLM_* 覆盖（primary 段三要素）；未传走 .env 透传。 */
+  aiEnvironment?: Record<string, string>
+}
+
 export class KnowledgeServiceSupervisor {
   private child: ChildProcessWithoutNullStreams | null = null
   private connection: KnowledgeServiceConnection | null = null
@@ -50,7 +55,7 @@ export class KnowledgeServiceSupervisor {
 
   constructor(private readonly dataDirectory: string) {}
 
-  async start(): Promise<KnowledgeServiceConnection | null> {
+  async start(options: KnowledgeServiceStartOptions = {}): Promise<KnowledgeServiceConnection | null> {
     if (this.connection) return this.connection
 
     if (
@@ -95,6 +100,7 @@ export class KnowledgeServiceSupervisor {
           // 服务默认 debug;托管实例跟随桌面日志级别。
           LOG_LEVEL: process.env.NXCORE_KNOWLEDGE_LOG_LEVEL?.trim() ?? 'info',
           ...this.llmEnvironment(),
+          ...(options.aiEnvironment ?? {}),
           ...(app.isPackaged ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
         },
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -136,6 +142,14 @@ export class KnowledgeServiceSupervisor {
 
   getConnection(): KnowledgeServiceConnection | null {
     return this.connection
+  }
+
+  /** runtime config 变更后带新 LLM env 重启托管实例；复用/外部实例原样返回。 */
+  async restart(aiEnvironment: Record<string, string> | null): Promise<KnowledgeServiceConnection | null> {
+    const connection = this.connection
+    if (!connection?.managed) return connection
+    await this.shutdown()
+    return this.start({ aiEnvironment: aiEnvironment ?? undefined })
   }
 
   getLastError(): string | null {

--- a/apps/desktop/src/main/knowledge/llm-env.ts
+++ b/apps/desktop/src/main/knowledge/llm-env.ts
@@ -1,0 +1,35 @@
+/**
+ * runtime config primary 段 → Knowledge Service（Wiki 引擎）LLM_* 环境变量。
+ *
+ * KS 子进程没有 RuntimeConfigManager，spawn env 是唯一配置通道
+ * （knowledge-supervisor llmEnvironment 已把 NXCORE_AI_* 映射为 LLM_*；
+ * .env 清空迁移 runtime config 后那段映射失效，本模块补 runtime 侧来源）。
+ * KS config.ts 的 LLM 表面：LLM_MODE/PROTOCOL/PROVIDER/API_KEY/MODEL/
+ * BASE_URL/MAX_TOKENS。三项（baseUrl/apiKey/model）全非空才算已配置，
+ * 未配置返回 null（保持 .env 透传，不注入半套——LLM_MODE=custom 无 key
+ * 会让 wiki ingest 直接报"LLM apiKey 未配置"）。
+ */
+
+/** runtime config primary 段 → KS LLM_*（custom 直连模式）；未配置返回 null。 */
+export function knowledgeServiceLlmEnv(
+  config: Record<string, unknown> | undefined | null,
+): Record<string, string> | null {
+  const primary = config?.primary
+  const value = primary && typeof primary === 'object' && !Array.isArray(primary)
+    ? primary as Record<string, unknown>
+    : {}
+  const text = (key: string): string => {
+    const raw = value[key]
+    return typeof raw === 'string' ? raw.trim() : ''
+  }
+  const baseUrl = text('baseUrl')
+  const apiKey = text('apiKey')
+  const model = text('model')
+  if (!baseUrl || !apiKey || !model) return null
+  return {
+    LLM_MODE: 'custom',
+    LLM_BASE_URL: baseUrl,
+    LLM_API_KEY: apiKey,
+    LLM_MODEL: model,
+  }
+}

--- a/apps/gateway/src/modules/knowledge/router.ts
+++ b/apps/gateway/src/modules/knowledge/router.ts
@@ -150,6 +150,11 @@ export class KnowledgeRouter {
     this.deps.embedding = embedding;
   }
 
+  /** runtime config 变更后替换抽取/判定 LLM（null = 关闭：抽取落未识别栏）。 */
+  replaceLlm(llm: RouterDeps["llm"]): void {
+    this.deps.llm = llm;
+  }
+
   /**
    * 跑完整瀑布并落 decision 行。
    * skipEntry：revert 后重路由时跳过 ①（否则同 Room 直连死循环）。

--- a/apps/gateway/src/modules/knowledge/service.ts
+++ b/apps/gateway/src/modules/knowledge/service.ts
@@ -380,9 +380,10 @@ export class KnowledgeService {
   private readonly registry: RoomWikiRegistry;
   private readonly entityRegistry: EntityRegistry;
   private readonly router: KnowledgeRouter;
-  private readonly llm: KnowledgeLlm | null;
+  private llm: KnowledgeLlm | null;
+  private readonly externalAgentResolver: AgentResolver | null;
   private readonly roomContextCache = new Map<string, { key: string; value: RoomContextSummary }>();
-  private readonly ownedAgentResolver: AgentResolver | null;
+  private ownedAgentResolver: AgentResolver | null;
   /** 字节与登记表的唯一所有者是 modules/files（U9）；此处仅编排路由/ingest。 */
   private readonly files: FilesService;
   private readonly pendingSchedules = new Map<string, PendingSchedule>();
@@ -413,6 +414,7 @@ export class KnowledgeService {
       ? createKnowledgeAgentResolver(config.dataDir, config.llm)
       : null;
     this.llm = config.llm ? new KnowledgeLlm(agentResolver ?? this.ownedAgentResolver!) : null;
+    this.externalAgentResolver = agentResolver ?? null;
     const embedding = config.embeddingLlm && config.embeddingModel
       ? { client: new EmbeddingClient(config.embeddingLlm, config.embeddingModel), model: config.embeddingModel }
       : null;
@@ -437,6 +439,21 @@ export class KnowledgeService {
   /** runtime config 变更后替换消歧 tie-break 的 embedding 端点（null = 关闭）。 */
   replaceEmbedding(embedding: { client: EmbeddingClient; model: string } | null): void {
     this.router.replaceEmbedding(embedding);
+  }
+
+  /**
+   * runtime config 变更后替换抽取/判定 LLM（null = 关闭）。boot 时 env 未配
+   * NXCORE_KNOWLEDGE_LLM_*、SaaS/用户配置稍后到达的场景由此补上；llm 到位
+   * 同时按需自建 ownedAgentResolver（主进程注入的 resolver 缺 knowledge
+   * agent 时 registerAgent 兜底在 create-server onChange 里做）。
+   */
+  replaceLlm(llm: KnowledgeLlmConfig | null): void {
+    if (!llm) return;
+    if (!this.llm && !this.ownedAgentResolver && !this.externalAgentResolver) {
+      this.ownedAgentResolver = createKnowledgeAgentResolver(this.config.dataDir, llm);
+    }
+    this.llm = new KnowledgeLlm(this.externalAgentResolver ?? this.ownedAgentResolver!);
+    this.router.replaceLlm(this.llm);
   }
 
   /** supervisor 生命周期钩子：崩溃恢复清扫 + 启动 worker 轮询。 */

--- a/apps/gateway/src/server/create-server.ts
+++ b/apps/gateway/src/server/create-server.ts
@@ -628,6 +628,11 @@ export async function createServer(config: GatewayConfig, overrides: ServerOverr
       });
       app.log.info("knowledge agent registered from runtime config");
     }
+    // 抽取/判定 LLM 同步热替换：KnowledgeService 构造于 runtime config 到达
+    // 之前，boot 时 llm 冻结为 null——不替换的话路由永远走「未识别」出口。
+    if (config.knowledge?.llm) {
+      knowledgeService.replaceLlm(config.knowledge.llm);
+    }
     void (async () => {
       try {
         const primary = agentResolver.reload(BUILTIN_AGENT_IDS.primary);


### PR DESCRIPTION
## 背景

`.env` 的 `NXCORE_AI_*` 清空迁移 runtime config 后，Room 自动归类的两条 LLM 链路各自断掉（本机日志与 `route_decisions` 均已确认）：

1. **gateway 路由瀑布**：所有资料落 `awaiting_review`，reason=「抽取 LLM 未配置」
2. **Knowledge Service（Wiki 引擎）子进程**：wiki ingest 失败——「LLM apiKey 未配置：proxy 模式需 TMC 为该 service_id 推送 llm_binding」

## 根因

### 链路 1：llm 构造期冻结
`KnowledgeService` 在 `createServer` 早期构造，早于 SaaS/user runtime config 到达（本机实测间隔约 6 秒）。`llm` 为 `readonly`、构造时定格为 null。64faae7 已修了一半——`applyRuntimeConfig` 用 primary 三要素回退 `knowledge.llm` 并注册 knowledge agent——但从未注入已建好的 router（embedding 有 `replaceEmbedding` 热替换，llm 没有对应入口）。

### 链路 2：KS 子进程漏配同步
Wiki 引擎（`@tencentdb-agent-memory/knowledge-service`）的 LLM 只认 spawn 时的 `LLM_*` env（由 `NXCORE_AI_*` 映射，清空后为空）。MemoryCore 已有「runtime config → env → 重启子进程」的同步（`syncMemoryCoreEnvironment`），KS 没有同款。

## 修复

**gateway 侧**（对齐既有 `replaceEmbedding` 模式）：
- `KnowledgeRouter.replaceLlm()`：`deps.llm` 可变化
- `KnowledgeService.replaceLlm()`：重建 `KnowledgeLlm` 并透传 router（无外部 resolver 时按需自建 owned resolver）
- `create-server.ts` onChange：注册 knowledge agent 之后同步热替换

**desktop 侧**（复刻 MemoryCore 模式）：
- `KnowledgeServiceSupervisor`：`start()` 接受 `aiEnvironment` 覆盖；新增 `restart()`
- `knowledge/llm-env.ts`（新）：runtime config primary 三要素 → `LLM_MODE=custom + LLM_BASE_URL/API_KEY/MODEL`；不齐全返回 null（不注入半套，避免 `LLM_MODE=custom` 无 key 直接报错）
- `syncKnowledgeServiceEnvironment()` 接进 `syncManagedChildProcesses` 总入口：JSON 比较去重，配置没变不重启；复用/外部实例（8421 被占）不标记 applied，下次 sync 重试

## 生效时序

冷启动：KS 先带空 env 起来 → gateway ready → startup sync 用已存 primary 重启 KS 注入 `LLM_API_KEY`（桌面日志 `[knowledge] ai env applied (instance restarted)`）。后续 runtime config 变更走同一同步链。

## 验证

- `apps/gateway`、`apps/desktop` `tsc --noEmit` 通过
- 存量积压说明：已落 `awaiting_review` 的决策不会自动重路由，需在未识别栏手动挂载或走 re-route；wiki 侧失败 job 由 worker 退避重试自愈

🤖 Generated with [Claude Code](https://claude.com/claude-code)