### PR TITLE
fix: 优化 macOS 启动时的钥匙串授权体验

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -53,7 +53,7 @@ import { DocumentGatewayBridge } from './gateway/document-gateway-bridge'
 import { KnowledgeGatewayBridge } from './gateway/knowledge-gateway-bridge'
 import { McpGatewayBridge } from './gateway/mcp-gateway-bridge'
 import { ExternalCallsGatewayBridge } from './gateway/external-calls-gateway-bridge'
-import { loadOrCreateGatewaySecretKey } from './security/gateway-secret-key'
+import { loadOrCreateGatewaySecretKey, shouldUnlockGatewaySecrets } from './security/gateway-secret-key'
 import { FilesGatewayBridge } from './gateway/files-gateway-bridge'
 import { IngestGatewayBridge } from './gateway/ingest-gateway-bridge'
 import { ContextRoomGatewayBridge } from './gateway/context-room-gateway-bridge'
@@ -2131,10 +2131,14 @@ function registerAccountHandlers(
   client: SaasClient,
   onAccountChanged?: (account: CloudAccountStatus) => void,
   beforeLogout?: () => Promise<void>,
-  afterLogin?: () => Promise<void>,
+  afterAuthenticated?: () => Promise<void>,
 ): void {
   handle(ACCOUNT_CHANNELS.status, (_event, refreshSubscription?: unknown) => rateLimitAware(async () => {
-    const account = await syncAccountMonitoring(client.status(refreshSubscription === true))
+    const userInitiated = refreshSubscription === true
+    const account = await syncAccountMonitoring(client.status(userInitiated))
+    if (shouldUnlockGatewaySecrets(account.authenticated, userInitiated)) {
+      void afterAuthenticated?.().catch((error) => console.warn('Gateway secrets stay locked.', error))
+    }
     onAccountChanged?.(account)
     return account
   }))
@@ -2149,7 +2153,7 @@ function registerAccountHandlers(
     const password = value.password
     return rateLimitAware(async () => {
       const account = await syncAccountMonitoring(client.login(identifier, password))
-      if (account.authenticated) void afterLogin?.().catch((error) => console.warn('Gateway secrets stay locked.', error))
+      if (account.authenticated) void afterAuthenticated?.().catch((error) => console.warn('Gateway secrets stay locked.', error))
       onAccountChanged?.(account)
       return account
     })
@@ -2166,7 +2170,7 @@ function registerAccountHandlers(
     const invitationCode=typeof value.invitationCode==='string'?value.invitationCode:undefined
     return rateLimitAware(async () => {
       const account = await syncAccountMonitoring(client.loginWithOidc(provider,invitationCode))
-      if (account.authenticated) void afterLogin?.().catch((error) => console.warn('Gateway secrets stay locked.', error))
+      if (account.authenticated) void afterAuthenticated?.().catch((error) => console.warn('Gateway secrets stay locked.', error))
       onAccountChanged?.(account)
       return account
     })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2131,6 +2131,7 @@ function registerAccountHandlers(
   client: SaasClient,
   onAccountChanged?: (account: CloudAccountStatus) => void,
   beforeLogout?: () => Promise<void>,
+  afterLogin?: () => Promise<void>,
 ): void {
   handle(ACCOUNT_CHANNELS.status, (_event, refreshSubscription?: unknown) => rateLimitAware(async () => {
     const account = await syncAccountMonitoring(client.status(refreshSubscription === true))
@@ -2148,6 +2149,7 @@ function registerAccountHandlers(
     const password = value.password
     return rateLimitAware(async () => {
       const account = await syncAccountMonitoring(client.login(identifier, password))
+      if (account.authenticated) void afterLogin?.().catch((error) => console.warn('Gateway secrets stay locked.', error))
       onAccountChanged?.(account)
       return account
     })
@@ -2164,6 +2166,7 @@ function registerAccountHandlers(
     const invitationCode=typeof value.invitationCode==='string'?value.invitationCode:undefined
     return rateLimitAware(async () => {
       const account = await syncAccountMonitoring(client.loginWithOidc(provider,invitationCode))
+      if (account.authenticated) void afterLogin?.().catch((error) => console.warn('Gateway secrets stay locked.', error))
       onAccountChanged?.(account)
       return account
     })
@@ -2476,9 +2479,8 @@ if (hasSingleInstanceLock) app.whenReady().then(async () => {
   if (process.platform === 'darwin' && !app.isPackaged) {
     app.dock?.setIcon(join(app.getAppPath(), 'build/icon.png'))
   }
-  const gatewaySecretStoreKey = await loadOrCreateGatewaySecretKey(
-    join(dataDirectory, 'security', 'gateway-master-key.json'),
-  )
+  const gatewaySecretStoreKeyPath = join(dataDirectory, 'security', 'gateway-master-key.json')
+  let gatewaySecretStoreKey = await loadOrCreateGatewaySecretKey(gatewaySecretStoreKeyPath)
   // 窗口先显示,Gateway 等服务在后台初始化,状态由左下角 Gateway 指示器呈现。
   const documentAssets = new DocumentAssetStore(join(dataDirectory, 'document-assets'))
   await documentAssets.initialize().catch((error) => {
@@ -2600,7 +2602,7 @@ if (hasSingleInstanceLock) app.whenReady().then(async () => {
     })
     gatewaySupervisor = new GatewaySupervisor(
       dataDirectory,
-      {
+      () => ({
         // packaged app 无 .env，gateway 默认 agentRuntime=fake（假流式响应）；
         // 显式注入 pi——AI 四要素由 runtime config 兜底（降级启动到配置完成）。
         NXCORE_AGENT_RUNTIME: 'pi',
@@ -2637,7 +2639,7 @@ if (hasSingleInstanceLock) app.whenReady().then(async () => {
             NXCORE_KNOWLEDGE_ROOM_WIKIS_ENABLED: 'true',
           }
           : {}),
-      },
+      }),
     )
     const gateway = await gatewaySupervisor.start()
     console.info(`NxCore Gateway ready at ${gateway.baseUrl} (pid=${gateway.pid})`)
@@ -2824,7 +2826,13 @@ if (hasSingleInstanceLock) app.whenReady().then(async () => {
         transcriptionProcessingCoordinator?.wake()
         void macosPushNotifications?.registerAuthenticatedDevice()
       }
-    }, () => macosPushNotifications?.beforeLogout() ?? Promise.resolve())
+    }, () => macosPushNotifications?.beforeLogout() ?? Promise.resolve(), async () => {
+      if (gatewaySecretStoreKey || process.platform !== 'darwin') return
+      gatewaySecretStoreKey = await loadOrCreateGatewaySecretKey(gatewaySecretStoreKeyPath, true)
+      if (!gatewaySecretStoreKey || !gatewaySupervisor) return
+      await gatewaySupervisor.shutdown()
+      await gatewaySupervisor.start()
+    })
     registerRuntimeConfigHandlers(saasClient)
     registerPrivateTranscriptionHandlers(privateTranscriptionSync, publishSyncCompleted)
     registerAsrHandlers(recordingStore,new AsrCoordinator(new AsrGatewayBridge(gatewaySupervisor),saasClient,realityGatewayBridge,privateAudioSync,privateTranscriptionSync))

--- a/apps/desktop/src/main/security/gateway-secret-key.ts
+++ b/apps/desktop/src/main/security/gateway-secret-key.ts
@@ -7,8 +7,11 @@ function isBasicTextStorage(): boolean {
   return process.platform === 'linux' && safeStorage.getSelectedStorageBackend?.() === 'basic_text'
 }
 
-export async function loadOrCreateGatewaySecretKey(filePath: string): Promise<string | null> {
-  if (!safeStorage.isEncryptionAvailable() || isBasicTextStorage()) {
+export async function loadOrCreateGatewaySecretKey(
+  filePath: string,
+  allowKeychainAccess = process.platform !== 'darwin',
+): Promise<string | null> {
+  if (!allowKeychainAccess || (process.platform !== 'darwin' && !safeStorage.isEncryptionAvailable()) || isBasicTextStorage()) {
     return null
   }
   try {

--- a/apps/desktop/src/main/security/gateway-secret-key.ts
+++ b/apps/desktop/src/main/security/gateway-secret-key.ts
@@ -7,6 +7,10 @@ function isBasicTextStorage(): boolean {
   return process.platform === 'linux' && safeStorage.getSelectedStorageBackend?.() === 'basic_text'
 }
 
+export function shouldUnlockGatewaySecrets(authenticated: boolean, userInitiated: boolean): boolean {
+  return authenticated && userInitiated
+}
+
 export async function loadOrCreateGatewaySecretKey(
   filePath: string,
   allowKeychainAccess = process.platform !== 'darwin',

--- a/apps/desktop/tests/gateway-secret-key.test.ts
+++ b/apps/desktop/tests/gateway-secret-key.test.ts
@@ -18,7 +18,7 @@ vi.mock('electron', () => ({
   },
 }))
 
-import { loadOrCreateGatewaySecretKey } from '../src/main/security/gateway-secret-key'
+import { loadOrCreateGatewaySecretKey, shouldUnlockGatewaySecrets } from '../src/main/security/gateway-secret-key'
 
 const directories: string[] = []
 
@@ -32,6 +32,12 @@ afterEach(async () => {
 })
 
 describe('gateway secret key', () => {
+  it('unlocks restored sessions only after an explicit account refresh', () => {
+    expect(shouldUnlockGatewaySecrets(true, false)).toBe(false)
+    expect(shouldUnlockGatewaySecrets(true, true)).toBe(true)
+    expect(shouldUnlockGatewaySecrets(false, true)).toBe(false)
+  })
+
   it('allows startup without creating a plaintext fallback when secure storage is unavailable', async () => {
     const root = await mkdtemp(join(tmpdir(), 'everroom-gateway-key-test-'))
     directories.push(root)

--- a/apps/desktop/tests/gateway-secret-key.test.ts
+++ b/apps/desktop/tests/gateway-secret-key.test.ts
@@ -1,13 +1,20 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const storageState = vi.hoisted(() => ({ available: false, backend: 'gnome' }))
+const storageState = vi.hoisted(() => ({ available: false, backend: 'gnome', availabilityChecks: 0, decryptions: 0 }))
 vi.mock('electron', () => ({
   safeStorage: {
-    isEncryptionAvailable: () => storageState.available,
+    isEncryptionAvailable: () => {
+      storageState.availabilityChecks += 1
+      return storageState.available
+    },
     getSelectedStorageBackend: () => storageState.backend,
+    decryptString: () => {
+      storageState.decryptions += 1
+      return Buffer.alloc(32).toString('base64url')
+    },
   },
 }))
 
@@ -20,6 +27,8 @@ afterEach(async () => {
   await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })))
   storageState.available = false
   storageState.backend = 'gnome'
+  storageState.availabilityChecks = 0
+  storageState.decryptions = 0
 })
 
 describe('gateway secret key', () => {
@@ -40,5 +49,21 @@ describe('gateway secret key', () => {
     directories.push(root)
 
     await expect(loadOrCreateGatewaySecretKey(join(root, 'gateway-master-key.json'))).resolves.toBeNull()
+  })
+
+  it('does not access macOS Keychain during startup', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const root = await mkdtemp(join(tmpdir(), 'everroom-gateway-key-test-'))
+    directories.push(root)
+    const path = join(root, 'gateway-master-key.json')
+    await writeFile(path, JSON.stringify({ version: 1, encrypted: 'encrypted' }))
+
+    await expect(loadOrCreateGatewaySecretKey(path)).resolves.toBeNull()
+    expect(storageState.availabilityChecks).toBe(0)
+    expect(storageState.decryptions).toBe(0)
+
+    await expect(loadOrCreateGatewaySecretKey(path, true)).resolves.toBe(Buffer.alloc(32).toString('base64url'))
+    expect(storageState.availabilityChecks).toBe(0)
+    expect(storageState.decryptions).toBe(1)
   })
 })


### PR DESCRIPTION
## 更改内容

- macOS 冷启动时不再访问钥匙串，避免应用一启动就弹出系统密码框。
- 用户主动登录成功后才解锁 Gateway 主密钥，并重启 Gateway 使敏感配置正常加载。
- 已恢复登录态的用户可在设置页主动刷新账户状态来解锁密钥；后台 quiet 状态探测仍不会访问钥匙串。
- Windows 和 Linux 保持原有行为不变。
- 增加回归测试，覆盖冷启动零钥匙串访问、显式登录解锁和已有会话主动刷新解锁。

## 验证

- Desktop 定向测试：9 条全部通过。
- Desktop TypeScript 类型检查通过。
- Git diff 检查通过。

## 审查处理

- 接受审查指出的 已有登录态缺少可达解锁路径问题。
- 未采用冷启动自动解锁，因为会重新引入启动即弹系统密码框；改为复用设置页的用户主动刷新入口。

## 说明

截图中的连接报错来自原有的登录后 MemoryCore 重启短暂不可用，并非本次改动引入，因此本 PR 不处理该问题。