### PR TITLE
ci: 增加桌面端 Alpha 手动发版并区分 Nightly

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -254,7 +254,7 @@ jobs:
           name: macos-assets
           path: release-assets
 
-      - name: Publish prerelease
+      - name: Publish desktop release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -282,9 +282,13 @@ jobs:
           else
             notes="Unsigned Apple Silicon development builds. macOS Gatekeeper may require manual approval before first launch."
           fi
+          release_flags=(--latest)
+          if [[ "$GITHUB_REF_NAME" == *-nightly.* ]]; then
+            release_flags=(--prerelease --latest=false)
+          fi
           gh release create "$GITHUB_REF_NAME" "${expected[@]}" \
             --verify-tag \
-            --prerelease \
+            "${release_flags[@]}" \
             --generate-notes \
             --notes "$notes"
 

--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -81,7 +81,7 @@ jobs:
               echo "tag-exists=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            tag="$(git tag --points-at HEAD --list "desktop-v$version*" --sort=-version:refname | head -n 1)"
+            tag="$(git tag --points-at HEAD --list "desktop-v$version-nightly.*" --sort=-version:refname | head -n 1)"
             if [[ -n "$tag" ]]; then
               echo "tag-exists=true" >> "$GITHUB_OUTPUT"
             else

--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -5,6 +5,15 @@ on:
     # 00:00 Asia/Shanghai (UTC+8). GitHub schedules use UTC.
     - cron: "0 16 * * *"
   workflow_dispatch:
+    inputs:
+      channel:
+        description: Release channel
+        required: true
+        default: nightly
+        type: choice
+        options:
+          - nightly
+          - alpha
 
 permissions:
   actions: write
@@ -52,6 +61,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_CHANNEL: ${{ inputs.channel || 'nightly' }}
         run: |
           version="$(node -p "require('./apps/desktop/package.json').version")"
           [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
@@ -59,12 +69,25 @@ jobs:
             exit 1
           }
           git fetch origin 'refs/tags/desktop-v*:refs/tags/desktop-v*'
-          tag="$(git tag --points-at HEAD --list "desktop-v$version*" --sort=-version:refname | head -n 1)"
-          if [[ -n "$tag" ]]; then
-            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+          if [[ "$RELEASE_CHANNEL" == "alpha" ]]; then
+            tag="desktop-v$version"
+            if git show-ref --verify --quiet "refs/tags/$tag"; then
+              test "$(git rev-list -n 1 "$tag")" = "$(git rev-parse HEAD)" || {
+                echo "Tag $tag already points to another commit; update the desktop package version." >&2
+                exit 1
+              }
+              echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "tag-exists=false" >> "$GITHUB_OUTPUT"
+            fi
           else
-            tag="desktop-v$version-nightly.$(TZ=Asia/Shanghai date +%Y%m%d).$GITHUB_RUN_NUMBER"
-            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
+            tag="$(git tag --points-at HEAD --list "desktop-v$version*" --sort=-version:refname | head -n 1)"
+            if [[ -n "$tag" ]]; then
+              echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+            else
+              tag="desktop-v$version-nightly.$(TZ=Asia/Shanghai date +%Y%m%d).$GITHUB_RUN_NUMBER"
+              echo "tag-exists=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## 修改内容

- 在每日桌面端发布工作流中增加 `nightly` 和 `alpha` 手动选项。
- 定时任务继续发布 nightly，并明确标记为 Pre-release，不再占用 Latest。
- 手动 Alpha 发布读取桌面端 `package.json` 版本，从 `main` 最新提交创建普通版本标签并设为 Latest。
- Alpha 标签已指向其他提交时直接失败，避免覆盖已有版本。

## 保持不变

- macOS 构建、签名和公证流程。
- 类型检查、构建、产物检查及飞书通知流程。

## 验证

- `pnpm dlx yaml-lint .github/workflows/scheduled-desktop-release.yml .github/workflows/release-desktop.yml`
- `git diff --check`
- 已确认 `desktop-v0.1.6` 为 Latest，`desktop-v0.1.5-nightly.20260829.25` 为 Pre-release。
