### PR TITLE
feat(diary): enable scheduled daily summary by default

### DIFF
--- a/apps/gateway/src/modules/diary/service.ts
+++ b/apps/gateway/src/modules/diary/service.ts
@@ -28,6 +28,8 @@ export type {
 } from "./types.js";
 
 const DEFAULT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+// 定时总结默认开启：新装与从未配置过的老库都直接进入自动生成状态。
+const DEFAULT_LOCAL_TIME = "23:30";
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const TIME = /^([01]\d|2[0-3]):[0-5]\d$/;
 
@@ -75,6 +77,7 @@ export class DiaryService {
   private readonly sourceCollector: DiarySourceCollector;
   private timer: NodeJS.Timeout | null = null;
   private drainPromise: Promise<void> | null = null;
+  private drainAgain = false;
   private readonly refreshTimers = new Map<string, NodeJS.Timeout>();
   private readonly staleCheckAt = new Map<string, number>();
   private readonly backfilledDates = new Set<string>();
@@ -143,10 +146,39 @@ export class DiaryService {
   }
 
   getSettings(): typeof diarySchedules.$inferSelect {
-    const row = this.db.select().from(diarySchedules).where(eq(diarySchedules.ownerId, this.options.ownerId)).get();
-    if (row) return row;
+    let row = this.db.select().from(diarySchedules).where(eq(diarySchedules.ownerId, this.options.ownerId)).get();
+    if (row) {
+      // 老库里“从未配置过”的行（默认关闭时代自动建出、用户没动过开关）升级为
+      // 默认开启；用户显式关闭过的行（configVersion 已前移或已写过 enabledFrom）
+      // 不动。enabledFrom 落在升级当天，避免突然回填数月的历史日记。
+      if (!row.enabled && row.enabledFrom === null && row.configVersion === 1) {
+        const now = this.now();
+        const timezone = row.timezone || DEFAULT_TIMEZONE;
+        this.db.update(diarySchedules).set({
+          enabled: true,
+          enabledFrom: dateInTimezone(now, timezone),
+          nextRunAt: this.nextSchedule(now, row.localTime, timezone),
+          updatedAt: now,
+        }).where(eq(diarySchedules.ownerId, this.options.ownerId)).run();
+        this.logger?.info({ event: "diary.settings.default_enabled", timezone, localTime: row.localTime }, "diary scheduling upgraded to default-on");
+        row = this.db.select().from(diarySchedules).where(eq(diarySchedules.ownerId, this.options.ownerId)).get()!;
+      }
+      return row;
+    }
     const now = this.now();
-    this.db.insert(diarySchedules).values({ ownerId: this.options.ownerId, timezone: DEFAULT_TIMEZONE, createdAt: now, updatedAt: now }).run();
+    // 首次建行即默认开启：enabledFrom=今天、nextRunAt=下一个 23:30 槽位。
+    // 只把 enabled 置 true 而缺 nextRunAt 的话，外部调度器的定时槽位永远不触发
+    // （tick 只认 nextRunAt），当天之外的每日总结会静默丢失。
+    this.db.insert(diarySchedules).values({
+      ownerId: this.options.ownerId,
+      enabled: true,
+      localTime: DEFAULT_LOCAL_TIME,
+      timezone: DEFAULT_TIMEZONE,
+      enabledFrom: dateInTimezone(now, DEFAULT_TIMEZONE),
+      nextRunAt: this.nextSchedule(now, DEFAULT_LOCAL_TIME, DEFAULT_TIMEZONE),
+      createdAt: now,
+      updatedAt: now,
+    }).run();
     return this.db.select().from(diarySchedules).where(eq(diarySchedules.ownerId, this.options.ownerId)).get()!;
   }
 
@@ -378,9 +410,25 @@ export class DiaryService {
   }
 
   async drain(): Promise<void> {
-    if (this.drainPromise) return this.drainPromise;
-    this.drainPromise = this.drainInternal().finally(() => { this.drainPromise = null; });
-    return this.drainPromise;
+    if (this.drainPromise) {
+      // 已有 drain 在飞：标记补扫并让调用方等待完整循环。否则运行创建于本轮
+      // due 查询之后时，调用方拿到的 promise 不覆盖它，只能等 30s 轮询捡起
+      // （updateSettings 的 void drain() 与手动生成路由都会踩中这个窗口）。
+      this.drainAgain = true;
+      return this.drainPromise;
+    }
+    const execution = (async () => {
+      try {
+        do {
+          this.drainAgain = false;
+          await this.drainInternal();
+        } while (this.drainAgain);
+      } finally {
+        this.drainPromise = null;
+      }
+    })();
+    this.drainPromise = execution;
+    return execution;
   }
 
   private async drainInternal(): Promise<void> {

--- a/apps/gateway/tests/diary-service.test.ts
+++ b/apps/gateway/tests/diary-service.test.ts
@@ -10,6 +10,7 @@ import {
   connectorEmails,
   documents,
   documentVersions,
+  diarySchedules,
   diaryVersionSources,
   entities,
   entityDocLinks,
@@ -141,6 +142,48 @@ describe("DiaryService", () => {
     expect(runId).toEqual(expect.any(String));
     expect(service.getRun(runId!)).toMatchObject({ date: "2026-08-20", trigger: "scheduled" });
     expect(service.ensureCurrentDayRun()).toBeNull();
+  });
+
+  it("enables scheduled generation by default for fresh installs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nxcore-diary-test-"));
+    temporaryDirectories.push(dir);
+    const database = createDatabase(join(dir, "gateway.sqlite"), resolve("drizzle"));
+    databases.push(database);
+    const service = new DiaryService(database.db, { now: () => new Date(NOW) });
+
+    const settings = service.getSettings();
+
+    expect(settings.enabled).toBe(true);
+    expect(settings.localTime).toBe("23:30");
+    // enabledFrom/nextRunAt 跟随宿主机时区，只断言形态与先后关系。
+    expect(settings.enabledFrom).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(settings.nextRunAt).toBeInstanceOf(Date);
+    expect(settings.nextRunAt?.getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  it("upgrades never-configured legacy rows to default-on and respects explicit opt-outs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nxcore-diary-test-"));
+    temporaryDirectories.push(dir);
+    const database = createDatabase(join(dir, "gateway.sqlite"), resolve("drizzle"));
+    databases.push(database);
+    // 默认关闭时代自动建出、从未被用户改过的行。
+    database.db.insert(diarySchedules).values({
+      ownerId: "local-user", enabled: false, localTime: "23:30", timezone: "Asia/Shanghai",
+      enabledFrom: null, nextRunAt: null, configVersion: 1, createdAt: NOW, updatedAt: NOW,
+    }).run();
+    const service = new DiaryService(database.db, { now: () => new Date(NOW) });
+
+    const upgraded = service.getSettings();
+
+    expect(upgraded.enabled).toBe(true);
+    expect(upgraded.enabledFrom).toBe("2026-08-20");
+    expect(upgraded.nextRunAt).toEqual(new Date("2026-08-20T15:30:00.000Z"));
+    // 不前移 configVersion：持有旧版本的客户端下一次 PATCH 不应被 409 拒绝。
+    expect(upgraded.configVersion).toBe(1);
+
+    // 用户显式关闭后（configVersion 已前移、enabledFrom 已写入），默认值不得再把它打开。
+    service.updateSettings({ enabled: false });
+    expect(service.getSettings()).toMatchObject({ enabled: false, nextRunAt: null, configVersion: 2 });
   });
 
   it("limits source reads to the run manifest and marks a ready day stale after source changes", async () => {


### PR DESCRIPTION
Fresh settings rows are now created enabled with localTime 23:30, enabledFrom set to the current day, and nextRunAt armed so the externally managed scheduler fires the daily slot. Legacy rows that were never configured by the user are upgraded to default-on on read; explicit opt-outs are preserved, and configVersion is left untouched so clients holding an old version are not rejected with 409.

Also fix a drain() promise-dedup race exposed by default-on: a run created after an in-flight drain's due query had to wait for the 30s poll. Callers arriving mid-drain now request a rescan and await the full loop.