### PR TITLE
fix(desktop): add macOS audio input entitlement

### DIFF
--- a/apps/desktop/build/entitlements.mac.inherit.plist
+++ b/apps/desktop/build/entitlements.mac.inherit.plist
@@ -8,5 +8,7 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -10,5 +10,7 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- grant the packaged macOS app access to audio input
- propagate the entitlement to inherited child signatures

## Testing

- `plutil -lint apps/desktop/build/entitlements.mac.plist apps/desktop/build/entitlements.mac.inherit.plist`
- `git diff --check`