### PR TITLE
修复 Windows 安装包中 Nango 启动失败

### DIFF
--- a/apps/desktop/scripts/prepare-nango-runtime.mjs
+++ b/apps/desktop/scripts/prepare-nango-runtime.mjs
@@ -201,18 +201,22 @@ const materializeEscapingSymlinks = (directory) => {
 }
 materializeEscapingSymlinks(outputRoot)
 
-// pnpm materialized the `file:` workspace deps as real dirs under
-// packages/node_modules/@nangohq/*. @nangohq/utils computes projectRoot from
-// __filename (../../../..), so those copies shift the "repo root" to
-// packages/node_modules and break every projectRoot-relative resource
-// (migrations, flows.zero.json, ...). Replace them with relative symlinks
-// back to packages/<dir>: Node resolves module realpaths by default, so
-// __filename lands in packages/<dir> and projectRoot matches dev layout.
-for (const name of required) {
-  const { directory } = packageRoots.get(name)
-  const scoped = name.split('/')
-  const nmPath = join(outputRoot, 'packages', 'node_modules', ...scoped)
-  rmSync(nmPath, { recursive: true, force: true })
-  symlinkSync(join('../../', directory), nmPath, 'dir')
+// Windows installers materialize directory symlinks as regular directories.
+// Make the copied utils package resolve the runtime root directly there;
+// macOS keeps the existing symlink layout and therefore its current behavior.
+if (process.platform === 'win32') {
+  const pathModule = join(outputRoot, 'packages', 'node_modules', '@nangohq', 'utils', 'dist', 'path.js')
+  const source = readFileSync(pathModule, 'utf8')
+  const patched = source.replace("path.join(__filename, '../../../..')", "path.join(__filename, '../../../../../..')")
+  if (patched === source) throw new Error(`Unable to patch packaged Nango projectRoot: ${pathModule}`)
+  writeFileSync(pathModule, patched)
+} else {
+  for (const name of required) {
+    const { directory } = packageRoots.get(name)
+    const scoped = name.split('/')
+    const nmPath = join(outputRoot, 'packages', 'node_modules', ...scoped)
+    rmSync(nmPath, { recursive: true, force: true })
+    symlinkSync(join('../../', directory), nmPath, 'dir')
+  }
 }
 console.log(`Prepared Nango runtime at ${outputRoot}`)

--- a/apps/desktop/scripts/verify-windows-package.mjs
+++ b/apps/desktop/scripts/verify-windows-package.mjs
@@ -1,8 +1,9 @@
 // Audits the Windows packaging output without installing it: mirrors the
 // macOS "Audit package contents" CI step for the NSIS/win-unpacked layout.
 // Node standard library + the repo's existing @electron/asar only.
-import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { execFileSync, spawn } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { join, relative, resolve, sep } from 'node:path'
 import { listPackage } from '@electron/asar'
 
@@ -140,6 +141,52 @@ if (existsSync(ooExe)) {
     execFileSync(ooExe, ['--version'], { stdio: 'pipe', timeout: 60_000, windowsHide: true })
   } catch (error) {
     fail(`oo CLI --version failed: ${error.stderr?.toString() ?? error.message}`)
+  }
+}
+
+// Start the packaged Nango runtime once. Static file checks cannot catch
+// workspace links being materialized into a layout with a wrong projectRoot.
+const nangoEntry = join(nangoRoot, 'packages', 'server', 'dist', 'server.js')
+if (existsSync(appRoot) && existsSync(nangoEntry) && postgresBin.length > 0) {
+  const smokeRoot = join(releaseRoot, '.nango-smoke')
+  rmSync(smokeRoot, { recursive: true, force: true, maxRetries: 3 })
+  mkdirSync(smokeRoot, { recursive: true })
+  let output = ''
+  const child = spawn(appRoot, [nangoEntry], {
+    cwd: join(nangoRoot, 'packages', 'server'),
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: '1',
+      NANGO_EMBEDDED_DB: 'true',
+      NANGO_DB_PORT: '5433',
+      NANGO_EMBEDDED_DB_DIR: join(smokeRoot, 'embedded-postgres'),
+      NANGO_SERVER_URL: 'http://localhost:3003',
+      FLAG_AUTH_ENABLED: 'false',
+      NANGO_ENCRYPTION_KEY: randomBytes(32).toString('base64'),
+      SERVER_PORT: '3003',
+      NO_PROXY: '127.0.0.1,localhost,::1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+  child.stdout.on('data', (chunk) => { output = (output + chunk).slice(-8_000) })
+  child.stderr.on('data', (chunk) => { output = (output + chunk).slice(-8_000) })
+  try {
+    const deadline = Date.now() + 120_000
+    let ready = false
+    while (Date.now() < deadline && child.exitCode === null) {
+      try {
+        ready = (await fetch('http://127.0.0.1:3003/health', { signal: AbortSignal.timeout(1_000) })).ok
+      } catch {}
+      if (ready) break
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+    if (!ready) fail(`Packaged Nango health check failed (exit=${String(child.exitCode)}): ${output.trim()}`)
+  } finally {
+    try {
+      execFileSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true })
+    } catch {}
+    rmSync(smokeRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 250 })
   }
 }
 


### PR DESCRIPTION
## 背景

Windows 安装包会将 Nango workspace 目录符号链接物化为普通目录，导致 @nangohq/utils 计算出的 projectRoot 偏移到 packages/node_modules，运行时无法找到数据库迁移目录，最终 Nango 未监听 3003。

## 修改

- Windows staging 阶段修正打包后 @nangohq/utils 的 projectRoot 相对层级，使其指向 resources/nango。
- macOS 继续使用原有 workspace 符号链接流程，现有 macOS 打包逻辑和 CI 均未修改。
- Windows 包审计增加最小 Nango smoke test：启动包内 Nango 与 embedded PostgreSQL，等待 /health 成功后清理进程和临时数据。

## 验证

- pnpm typecheck 通过。
- pnpm test:ci 通过，共 56 项测试。
- 按 release workflow 完成 pnpm build、Windows x64 NSIS 打包和 package audit。
- 审计通过：17 个必需条目、7404 个 loose files、31479 个 asar entries。
- NSIS 静默安装退出码为 0。
- 使用全新用户数据目录启动已安装应用，MemoryCore、Knowledge、Gateway、Nango、Connect UI 均进入 ready，Nango /health 返回 200。