### PR TITLE
修复桌面打包 open-connector 依赖安装崩溃：改用 npm ci 可复现安装

### DIFF
--- a/apps/desktop/scripts/prepare-open-connector.mjs
+++ b/apps/desktop/scripts/prepare-open-connector.mjs
@@ -40,6 +40,7 @@ await rm(stagingDirectory, { recursive: true, force: true })
 
 for (const entry of [
   'package.json',
+  'package-lock.json',
   'tsconfig.json',
   'LICENSE.txt',
   'NOTICE.md',
@@ -55,7 +56,10 @@ for (const entry of [
 }
 
 try {
-  await run('npm', ['install', '--include=dev', '--ignore-scripts', '--no-audit', '--no-fund'], stagingDirectory)
+  // npm ci + lockfile: 浮动 install 会解析到 registry 最新版本，
+  // 曾因新发布的 @vitest/browser-playwright@5.0.0（peerDep 要求 vitest@5.0.0）
+  // 触发 npm arborist "Cannot read properties of null (reading 'edgesOut')" 崩溃。
+  await run('npm', ['ci', '--include=dev', '--ignore-scripts', '--no-audit', '--no-fund'], stagingDirectory)
   await run(process.execPath, ['scripts/ensure-generated.ts'], stagingDirectory)
   await applyEverRoomBranding(stagingDirectory)
   await run('npm', ['run', 'build:web'], stagingDirectory)


### PR DESCRIPTION
## 问题背景

[桌面发布 run #33759704773](https://github.com/NxcoreAI/EverRoom/actions/runs/33759704773) 中 macOS 与 Windows 两个平台在同一处失败：`prepare-open-connector.mjs` 报 `npm error Cannot read properties of null (reading 'edgesOut')`。

## 根因

**与任何代码提交无关**（PR #163 新增 Windows 打包后 macOS job 定义逐字节未变，脚本与 open-connector 源自 8/20 后均未改动），真正的触发者是时间上的巧合：

- 脚本复制 open-connector 源码时**不带 `package-lock.json`**，staging 目录用浮动 `npm install` 解析依赖
- 2026-09-03 12:22 UTC（上次成功构建之后、失败构建之前 50 分钟）npm 发布了 `@vitest/browser-playwright@5.0.0`，其 peerDep 要求 `vitest@5.0.0`
- 浮动解析将可选 peer 解析到 5.0.0，与实际解析到的 `vitest@4.1.11` 冲突，命中 npm arborist `#loadPeerSet` 的崩溃 bug
- 已在本机用相同命令复现出完全相同的错误

## 修复内容

`apps/desktop/scripts/prepare-open-connector.mjs`：

1. 复制文件列表加入 `package-lock.json`（open-connector 仓库自带，其中 `@vitest/browser-playwright` 锁定在安全的 4.1.9）
2. 安装命令 `npm install` → `npm ci`（`--include=dev --ignore-scripts --no-audit --no-fund` 参数保持不变）

已本地验证：同一 staging 目录下 `npm ci --include=dev --ignore-scripts --no-audit --no-fund` 正常通过（529 个包）。

## 后续影响

- 构建不再受 registry 新版本发布影响，安装完全可复现
- open-connector 升级依赖时需更新其仓库的 lockfile，EverRoom 侧再更新锁定的 tarball revision（多一步显式操作，换取构建确定性）
- `npm prune`、branding 替换、产物复制等其余逻辑不受影响
