### PR TITLE
修复 dev 类型错误并将发布通道拆分为 dev=nightly、alpha=正式

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -81,9 +81,11 @@ jobs:
             echo "Tag $GITHUB_REF_NAME does not match desktop version $version" >&2
             exit 1
           }
-          git fetch origin main --no-tags
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main || {
-            echo "Tagged commit must be on main" >&2
+          git fetch origin main dev alpha --no-tags
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main ||
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/dev ||
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/alpha || {
+            echo "Tagged commit must be on main, dev, or alpha" >&2
             exit 1
           }
 
@@ -290,9 +292,11 @@ jobs:
             echo "Tag $GITHUB_REF_NAME does not match desktop version $version" >&2
             exit 1
           }
-          git fetch origin main --no-tags
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main || {
-            echo "Tagged commit must be on main" >&2
+          git fetch origin main dev alpha --no-tags
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main ||
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/dev ||
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/alpha || {
+            echo "Tagged commit must be on main, dev, or alpha" >&2
             exit 1
           }
 

--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -48,10 +48,10 @@ jobs:
       NXCORE_BROWSER_EXTENSION_ID: ${{ vars.NXCORE_BROWSER_EXTENSION_ID }}
 
     steps:
-      - name: Check out main
+      - name: Check out release branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: ${{ inputs.channel == 'alpha' && 'alpha' || 'dev' }}
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive
@@ -180,7 +180,7 @@ jobs:
             exit 0
           fi
           message="EverRoom 每日发布检查失败
-          分支：main
+          分支：${{ inputs.channel == 'alpha' && 'alpha' || 'dev' }}
           提交：$(git log -1 --pretty='%h %s (%an)')
           日志：https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           payload="$(jq -n --arg text "$message" '{msg_type:"text",content:{text:$text}}')"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxcore/desktop",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "main": "./out/main/index.js",

--- a/apps/gateway/src/server/create-server.ts
+++ b/apps/gateway/src/server/create-server.ts
@@ -839,7 +839,7 @@ export async function createServer(config: GatewayConfig, overrides: ServerOverr
         updated_at: item.updatedAt,
       }));
     },
-  }, cliConnectorSyncService, nangoAgentTools);
+  }, cliConnectorSyncService);
   const agentRuntime = agentResolver.resolve(BUILTIN_AGENT_IDS.primary);
   const localAgentRuntimeRegistry = new LocalAgentRuntimeRegistry();
   app.log.info(


### PR DESCRIPTION
## 概述

本 PR 让发布通道与分支模型对齐：**dev 分支 = nightly 通道，alpha 分支 = 正式 release 通道**，同时修复 dev 分支上阻断 verify CI 的类型错误，并将桌面端版本号升级到 0.1.7。

## 改动内容

### 1. 修复 dev 分支类型错误
- `apps/gateway/src/server/create-server.ts:842`：移除 `createServer` 调用中多余的 `nangoAgentTools` 实参（dev 分支删除 Nango 重构的残留），verify CI 此前正是被该类型错误拦截。

### 2. 版本号升级
- `apps/desktop/package.json`：`0.1.6` → `0.1.7`。

### 3. release-desktop.yml 支持多分支
- macOS / Windows 两个 job 的 `Validate release tag` 步骤：tag 指向的提交原先必须位于 main，现放宽为 main / dev / alpha 任一分支（`git fetch origin main dev alpha --no-tags` 后依次做 `git merge-base --is-ancestor` 判断）。

### 4. scheduled-desktop-release.yml 按通道选分支
- checkout 的 `ref` 由固定 `main` 改为按 channel 映射：`nightly` → `dev`，`alpha` → `alpha`。
- tag 规则保持不变：nightly 生成带 `-nightly.YYYYMMDD.N` 后缀的 tag，alpha 生成无后缀的正式 tag。
- 飞书失败通知中的分支名同步改为随 channel 输出。

## 通道与分支对应关系

| channel | 分支 | tag 形态 | release 类型 |
|---------|------|----------|--------------|
| nightly | dev | `desktop-v0.1.7-nightly.YYYYMMDD.N` | prerelease |
| alpha | alpha | `desktop-v0.1.7` | 正式 |

## 验证
- `pnpm --filter @nxcore/gateway exec tsc --noEmit` 通过（0 错误）。