### PR TITLE
ci: 清理发布流程 Nango 残留，畅通 dev nightly 打包

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -60,14 +60,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          # Include the Nango submodule lockfile: the pnpm store is shared with
-          # the staging `pnpm install` in prepare-nango-runtime.mjs, whose deps
-          # are not covered by the root lockfile. Without this, the store cache
-          # key never changes when those deps change, the exact-key hit skips
-          # the post-job save, and the staging deps re-download every run.
-          cache-dependency-path: |
-            pnpm-lock.yaml
-            apps/gateway/src/modules/connector/package-lock.json
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Validate release tag
         shell: bash
@@ -92,14 +85,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Tarball cache for the `npm ci` runs inside prepare-nango-runtime.mjs
-      # (Nango submodule) and prepare-genoffice-runtime.mjs (genoffice
-      # submodule). The pnpm store above only covers pnpm installs.
+      # Tarball cache for the `npm ci` run inside prepare-genoffice-runtime.mjs
+      # (genoffice submodule). The pnpm store above only covers pnpm installs.
       - name: Cache npm tarballs for submodule builds
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
-          key: npm-tarballs-${{ runner.os }}-${{ hashFiles('apps/gateway/src/modules/connector/package-lock.json', 'apps/desktop/vendor/genoffice/package-lock.json') }}
+          key: npm-tarballs-${{ runner.os }}-${{ hashFiles('apps/desktop/vendor/genoffice/package-lock.json') }}
           restore-keys: npm-tarballs-${{ runner.os }}-
 
       # prepare-genoffice-runtime.mjs builds the Rust xlsx sidecar (cargo
@@ -143,7 +135,6 @@ jobs:
           pnpm --filter @nxcore/desktop exec node scripts/prepare-open-connector.mjs
           pnpm --filter @nxcore/desktop exec node scripts/prepare-oo-cli.mjs
           pnpm --filter @nxcore/desktop exec node scripts/generate-packaged-env.mjs
-          test -f apps/desktop/build/nango-runtime/packages/server/dist/server.js
 
       - name: Package macOS arm64
         shell: bash
@@ -177,17 +168,11 @@ jobs:
           resources="$app_path/Contents/Resources"
           forbidden='(^|/)(\.env($|\.)|(__tests__|tests?)(/|$)|[^/]*(\.test|\.spec)\.[^/]+$|(test|spec)\.[^/]+$)|\.map$'
 
-          # nango/ ships a vendored runtime whose compiled dist imports
-          # *.test.js and whose node_modules contains test fixtures — both
-          # required at runtime, so it is exempt from the loose-file audit.
-          loose_files="$(find "$resources" -type f -not -path "$resources/nango/*" -print)"
+          loose_files="$(find "$resources" -type f -print)"
           if printf '%s\n' "$loose_files" | grep -Eiq "$forbidden"; then
             printf '%s\n' "$loose_files" | grep -Ei "$forbidden" >&2
             exit 1
           fi
-          nango_loose="$(find "$resources/nango" -type f -print)"
-          printf '%s\n' "$nango_loose" | grep -Eiq '\.env($|\.)' && { printf '%s\n' "$nango_loose" | grep -Ei '\.env($|\.)' >&2; exit 1; }
-          printf '%s\n' "$nango_loose" | grep -Ei '\.(map|ts|tsx|mts|cts)$' && { printf '%s\n' "$nango_loose" | grep -Ei '\.(map|ts|tsx|mts|cts)$' >&2; exit 1; }
           unexpected_typescript="$(printf '%s\n' "$loose_files" | grep -Ei '\.(ts|tsx|mts|cts)$' | grep -Ev "^$resources/open-connector/" || true)"
           test -z "$unexpected_typescript" || { printf '%s\n' "$unexpected_typescript" >&2; exit 1; }
 
@@ -208,7 +193,6 @@ jobs:
           test -x "$resources/app.asar.unpacked/node_modules/@esbuild/darwin-arm64/bin/esbuild"
           test -f "$resources/app.asar.unpacked/node_modules/better-sqlite3/prebuilds/darwin-arm64.node"
           test -f "$resources/open-connector/src/server/index.ts"
-          test -f "$resources/nango/packages/server/dist/server.js"
           test -f "$resources/open-connector/dist/web/index.html"
           test -x "$resources/oo/darwin-arm64/oo"
           "$resources/oo/darwin-arm64/oo" --version
@@ -276,9 +260,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: |
-            pnpm-lock.yaml
-            apps/gateway/src/modules/connector/package-lock.json
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Validate release tag
         shell: bash
@@ -307,7 +289,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
-          key: npm-tarballs-${{ runner.os }}-${{ hashFiles('apps/gateway/src/modules/connector/package-lock.json', 'apps/desktop/vendor/genoffice/package-lock.json') }}
+          key: npm-tarballs-${{ runner.os }}-${{ hashFiles('apps/desktop/vendor/genoffice/package-lock.json') }}
           restore-keys: npm-tarballs-${{ runner.os }}-
 
       - name: Cache Rust build for xlsx sidecar
@@ -325,7 +307,6 @@ jobs:
           pnpm --filter @nxcore/desktop exec node scripts/prepare-open-connector.mjs
           pnpm --filter @nxcore/desktop exec node scripts/prepare-oo-cli.mjs
           pnpm --filter @nxcore/desktop exec node scripts/generate-packaged-env.mjs
-          test -f apps/desktop/build/nango-runtime/packages/server/dist/server.js
 
       - name: Package Windows x64
         shell: bash

--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -110,11 +110,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          # Include the Nango submodule lockfile so the shared pnpm store also
-          # persists the staging deps downloaded by prepare-nango-runtime.mjs.
-          cache-dependency-path: |
-            pnpm-lock.yaml
-            apps/gateway/src/modules/connector/package-lock.json
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         if: steps.candidate.outputs.pending == 'true'
@@ -125,7 +121,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
-          key: npm-tarballs-${{ runner.os }}-${{ hashFiles('apps/gateway/src/modules/connector/package-lock.json', 'apps/desktop/vendor/genoffice/package-lock.json') }}
+          key: npm-tarballs-${{ runner.os }}-${{ hashFiles('apps/desktop/vendor/genoffice/package-lock.json') }}
           restore-keys: npm-tarballs-${{ runner.os }}-
 
       - name: Cache Rust build for xlsx sidecar

--- a/apps/desktop/scripts/verify-windows-package.mjs
+++ b/apps/desktop/scripts/verify-windows-package.mjs
@@ -3,7 +3,7 @@
 // Node standard library + the repo's existing @electron/asar only.
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
-import { join, relative, resolve, sep } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import { listPackage } from '@electron/asar'
 
 const desktopRoot = resolve(import.meta.dirname, '..')
@@ -51,22 +51,12 @@ expectFile(join(resourcesRoot, 'packaged-env.json'), 'packaged-env.json')
 expectFile(join(resourcesRoot, 'app.asar'), 'app.asar')
 
 // --- Loose files under resources -------------------------------------------
-// nango/ ships a vendored runtime whose compiled dist imports *.test.js and
-// whose node_modules holds test fixtures — required at runtime, exempt from the
-// loose-file audit (same exemption as the macOS step) and audited separately.
-const nangoRoot = join(resourcesRoot, 'nango')
-const looseFiles = filesUnder(resourcesRoot).filter((path) => !path.startsWith(nangoRoot + sep))
+const looseFiles = filesUnder(resourcesRoot)
 for (const path of looseFiles) {
   const normalized = relative(resourcesRoot, path).split('\\').join('/')
   if (forbidden.test(normalized)) fail(`Forbidden loose file: ${normalized}`)
   if (typescript.test(normalized) && !normalized.startsWith('open-connector/')) {
     fail(`Unexpected TypeScript in package: ${normalized}`)
-  }
-}
-for (const path of filesUnder(join(resourcesRoot, 'nango'))) {
-  const normalized = relative(resourcesRoot, path).split('\\').join('/')
-  if (/(^|\/)\.env($|\.)/i.test(normalized) || /\.(map|ts|tsx|mts|cts)$/i.test(normalized)) {
-    fail(`Forbidden file in nango runtime: ${normalized}`)
   }
 }
 
@@ -121,12 +111,9 @@ expectFile(join(resourcesRoot, 'gateway', 'node_modules', 'better-sqlite3', 'pre
 const canvasNode = filesUnder(join(resourcesRoot, 'gateway', 'node_modules', '@napi-rs')).filter((path) => path.endsWith('.node'))
 if (canvasNode.length === 0) fail('gateway @napi-rs/canvas win32-x64 native is missing')
 
-// OpenConnector, Nango (with Windows embedded PostgreSQL), oo CLI, GenOffice.
+// OpenConnector, oo CLI, GenOffice.
 expectFile(join(resourcesRoot, 'open-connector', 'src', 'server', 'index.ts'), 'open-connector entry')
 expectFile(join(resourcesRoot, 'open-connector', 'dist', 'web', 'index.html'), 'open-connector web dist')
-expectFile(join(resourcesRoot, 'nango', 'packages', 'server', 'dist', 'server.js'), 'nango server entry')
-const postgresBin = filesUnder(join(resourcesRoot, 'nango')).filter((path) => /[\\/]postgres\.exe$/.test(path))
-if (postgresBin.length === 0) fail('nango windows-x64 embedded PostgreSQL (postgres.exe) is missing')
 const ooExe = join(resourcesRoot, 'oo', 'win32-x64', 'oo.exe')
 expectFile(ooExe, 'oo CLI win32-x64')
 expectFile(join(resourcesRoot, 'genoffice', 'native', 'xlsx-sidecar.exe'), 'genoffice xlsx-sidecar.exe')


### PR DESCRIPTION
## 概述

dev 分支删除 Nango 运行时后，发布 workflow 与 Windows 包审计脚本仍保留 Nango 硬性检查，会导致 nightly 打包必挂。本 PR 清理这些残留，使 dev 通道 nightly 可以顺利出包。

## 改动内容

### release-desktop.yml
- 删除两处 `test -f apps/desktop/build/nango-runtime/...`（macOS/Windows job 的 Build 步骤，Nango 构建产物已不存在）
- 删除 macOS Audit 中 nango 目录豁免与 `nango/packages/server/dist/server.js` 检查
- pnpm cache 与 npm tarball cache 不再引用已不存在的 `apps/gateway/src/modules/connector/package-lock.json`（connector 已是普通目录）

### scheduled-desktop-release.yml
- 同步清理两处 cache 配置中的 connector submodule lockfile 引用

### verify-windows-package.mjs
- 删除 nango 运行时审计段（loose-file 豁免、独立 forbidden 检查）
- 删除 nango server 入口与 Windows 内嵌 PostgreSQL（postgres.exe）必需检查

### 保留项
- `NXCORE_NANGO_*` 环境变量保留：gateway config 与 `generate-packaged-env.mjs` 仍在引用（命名遗留，属 P4 清理范畴）

## 验证
- `node --check verify-windows-package.mjs` 语法通过