### PR TITLE
ci: 发布流程注入 code.vyitec.com 私有 git 依赖凭证

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -82,6 +82,18 @@ jobs:
             exit 1
           }
 
+      - name: Configure private git credentials
+        shell: bash
+        env:
+          VYITEC_USER: ${{ secrets.VYITEC_USER }}
+          VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
+        run: |
+          cred_dir="$RUNNER_TEMP/vyitec-creds"
+          mkdir -p "$cred_dir"
+          printf 'protocol=https\nhost=code.vyitec.com\nusername=%s\npassword=%s\n' \
+            "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_dir/creds"
+          git config --global credential.helper "!f() { test \"$1\" = get && cat \"$RUNNER_TEMP/vyitec-creds/creds\"; }; f"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -281,6 +293,18 @@ jobs:
             echo "Tagged commit must be on main, dev, or alpha" >&2
             exit 1
           }
+
+      - name: Configure private git credentials
+        shell: bash
+        env:
+          VYITEC_USER: ${{ secrets.VYITEC_USER }}
+          VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
+        run: |
+          cred_dir="$RUNNER_TEMP/vyitec-creds"
+          mkdir -p "$cred_dir"
+          printf 'protocol=https\nhost=code.vyitec.com\nusername=%s\npassword=%s\n' \
+            "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_dir/creds"
+          git config --global credential.helper "!f() { test \"$1\" = get && cat \"$RUNNER_TEMP/vyitec-creds/creds\"; }; f"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -112,6 +112,19 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
+      - name: Configure private git credentials
+        if: steps.candidate.outputs.pending == 'true'
+        shell: bash
+        env:
+          VYITEC_USER: ${{ secrets.VYITEC_USER }}
+          VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
+        run: |
+          cred_dir="$RUNNER_TEMP/vyitec-creds"
+          mkdir -p "$cred_dir"
+          printf 'protocol=https\nhost=code.vyitec.com\nusername=%s\npassword=%s\n' \
+            "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_dir/creds"
+          git config --global credential.helper "!f() { test \"$1\" = get && cat \"$RUNNER_TEMP/vyitec-creds/creds\"; }; f"
+
       - name: Install dependencies
         if: steps.candidate.outputs.pending == 'true'
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## 背景

dev 分支的 `@oomol-lab/open-connector` 依赖改为私有 git 仓库（`code.vyitec.com/nexcore/everroom-openconnector.git#bd4213a`，来自 connector-unification 合并）。GitHub Actions runner 无法匿名克隆该仓库（`fatal: could not read Username`），nightly 预检在 `pnpm install` 即挂（run 34137181396）。

## 改动

在三个 `pnpm install` 前新增 `Configure private git credentials` 步骤（scheduled 预检 ×1、release-desktop macOS/Windows job ×2）：

- 从 secrets 读取 `VYITEC_USER` / `VYITEC_TOKEN`（已配置，token 仅 `read_repository` 最小权限）
- 凭证写入 `$RUNNER_TEMP/vyitec-creds/creds`（runner 临时目录，job 结束自动清理，不进 git config 明文）
- 配置全局 credential helper，仅对 `code.vyitec.com` 域生效

## 验证

合并后重新 dispatch `scheduled-desktop-release.yml`（channel=nightly）确认 install 通过。