### PR TITLE
ci: 修复 vyitec 凭证 helper 引号缺陷，改用 credential store

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -88,11 +88,9 @@ jobs:
           VYITEC_USER: ${{ secrets.VYITEC_USER }}
           VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
         run: |
-          cred_dir="$RUNNER_TEMP/vyitec-creds"
-          mkdir -p "$cred_dir"
-          printf 'protocol=https\nhost=code.vyitec.com\nusername=%s\npassword=%s\n' \
-            "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_dir/creds"
-          git config --global credential.helper "!f() { test \"$1\" = get && cat \"$RUNNER_TEMP/vyitec-creds/creds\"; }; f"
+          cred_file="$RUNNER_TEMP/vyitec-creds"
+          printf 'https://%s:%s@code.vyitec.com\n' "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_file"
+          git config --global credential.helper "store --file=$cred_file"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -300,11 +298,9 @@ jobs:
           VYITEC_USER: ${{ secrets.VYITEC_USER }}
           VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
         run: |
-          cred_dir="$RUNNER_TEMP/vyitec-creds"
-          mkdir -p "$cred_dir"
-          printf 'protocol=https\nhost=code.vyitec.com\nusername=%s\npassword=%s\n' \
-            "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_dir/creds"
-          git config --global credential.helper "!f() { test \"$1\" = get && cat \"$RUNNER_TEMP/vyitec-creds/creds\"; }; f"
+          cred_file="$RUNNER_TEMP/vyitec-creds"
+          printf 'https://%s:%s@code.vyitec.com\n' "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_file"
+          git config --global credential.helper "store --file=$cred_file"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -119,11 +119,9 @@ jobs:
           VYITEC_USER: ${{ secrets.VYITEC_USER }}
           VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
         run: |
-          cred_dir="$RUNNER_TEMP/vyitec-creds"
-          mkdir -p "$cred_dir"
-          printf 'protocol=https\nhost=code.vyitec.com\nusername=%s\npassword=%s\n' \
-            "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_dir/creds"
-          git config --global credential.helper "!f() { test \"$1\" = get && cat \"$RUNNER_TEMP/vyitec-creds/creds\"; }; f"
+          cred_file="$RUNNER_TEMP/vyitec-creds"
+          printf 'https://%s:%s@code.vyitec.com\n' "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_file"
+          git config --global credential.helper "store --file=$cred_file"
 
       - name: Install dependencies
         if: steps.candidate.outputs.pending == 'true'


### PR DESCRIPTION
## 问题

run 34138225986 预检失败：credential helper 未生效，`pnpm install` 克隆 `code.vyitec.com` 仍要求用户名。

## 根因

#187 写入的 helper 命令存在 shell 引号缺陷：外层双引号里的 `$1` 在执行 git config 时就被 bash 展开为空串，写入 config 的 helper 变成 `test "" = get`，对任何调用恒为假，凭证永远不输出。

## 修复

三处（scheduled 预检 ×1、release-desktop macOS/Windows ×2）改用标准 `credential.helper store`：

- 凭证以 `https://user:token@code.vyitec.com` 形式写入 `$RUNNER_TEMP/vyitec-creds`（仅限 https 协议 + 该域，runner 临时目录不落仓库）
- 配置命令无嵌套引号，无参数展开风险

## 验证

- 本地以同款 pnpm 11.15.1 + dev lockfile 完整跑通 `pnpm install --frozen-lockfile`（含 vyitec git 依赖克隆）与 `pnpm typecheck`（8 包 0 错误）——同时确认 dev 新合入的 PR #175/#185 代码类型健康，预检 typecheck 步骤不会翻车。
