### PR TITLE
ci: Windows 打包重置 credential helper 链，绕开 GCM 无交互失败

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           cred_file="$RUNNER_TEMP/vyitec-creds"
           printf 'https://%s:%s@code.vyitec.com\n' "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_file"
+          git config --global credential.helper ""
           git config --global credential.helper "store --file=$cred_file"
 
       - name: Install dependencies
@@ -300,6 +301,7 @@ jobs:
         run: |
           cred_file="$RUNNER_TEMP/vyitec-creds"
           printf 'https://%s:%s@code.vyitec.com\n' "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_file"
+          git config --global credential.helper ""
           git config --global credential.helper "store --file=$cred_file"
 
       - name: Install dependencies


### PR DESCRIPTION
## 问题

tag `desktop-v0.1.7-nightly.20260907.38` 打包：macOS job 全绿，Windows job 在 `Install dependencies` 失败（run 34139860380，job 101799185778）：

```
fatal: Cannot prompt because user interactivity has been disabled.
error: failed to execute prompt script (exit code 1)
fatal: could not read Username for 'https://code.vyitec.com'
```

## 根因

Windows runner 的 **system 级** gitconfig 预置了 Git Credential Manager（`credential.helper=manager`）。git 的 helper 是累积链：GCM 排在我们 #188 配置的 `store` helper 之前执行；GCM 在无交互的 CI 环境里尝试弹窗失败并以非零退出，git 直接中止认证流程，store helper 根本轮不到执行。Linux/macOS runner 无此预置，因此只有 Windows job 受影响。

## 修复

`release-desktop.yml` macOS/Windows 两处 `Configure private git credentials` 步骤中，在配置 store 前先写入空 helper 条目：

```
git config --global credential.helper ""
git config --global credential.helper "store --file=$cred_file"
```

空名 helper 是 git 官方语义，用于清空此前累积的全部 helper（含 system 级 GCM），随后仅保留我们的 store。

## 验证

- macOS job（同 tag、同凭证步骤）已确认全绿——store helper 本身工作正常，本修复只影响 helper 链顺序。
