### PR TITLE
ci: 改用 insteadOf URL 重写注入 vyitec 凭证，绕开 credential helper

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -88,10 +88,12 @@ jobs:
           VYITEC_USER: ${{ secrets.VYITEC_USER }}
           VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
         run: |
-          cred_file="$RUNNER_TEMP/vyitec-creds"
-          printf 'https://%s:%s@code.vyitec.com\n' "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_file"
-          git config --global credential.helper ""
-          git config --global credential.helper "store --file=$cred_file"
+          # 用 URL 重写注入凭证（insteadOf）：任何 git 调用（含 pnpm spawn 的
+          # clone）访问 code.vyitec.com 时自动改写为带凭证的 URL。不走
+          # credential helper——Windows runner 预置的 GCM 会抢跑且在无交互
+          # 环境弹窗失败，helper 链行为在三个平台不可控。
+          printf 'https://%s:%s@code.vyitec.com' "$VYITEC_USER" "$VYITEC_TOKEN" > "$RUNNER_TEMP/vyitec-url"
+          git config --global url."$(cat "$RUNNER_TEMP/vyitec-url")/".insteadOf "https://code.vyitec.com/"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -299,10 +301,12 @@ jobs:
           VYITEC_USER: ${{ secrets.VYITEC_USER }}
           VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
         run: |
-          cred_file="$RUNNER_TEMP/vyitec-creds"
-          printf 'https://%s:%s@code.vyitec.com\n' "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_file"
-          git config --global credential.helper ""
-          git config --global credential.helper "store --file=$cred_file"
+          # 用 URL 重写注入凭证（insteadOf）：任何 git 调用（含 pnpm spawn 的
+          # clone）访问 code.vyitec.com 时自动改写为带凭证的 URL。不走
+          # credential helper——Windows runner 预置的 GCM 会抢跑且在无交互
+          # 环境弹窗失败，helper 链行为在三个平台不可控。
+          printf 'https://%s:%s@code.vyitec.com' "$VYITEC_USER" "$VYITEC_TOKEN" > "$RUNNER_TEMP/vyitec-url"
+          git config --global url."$(cat "$RUNNER_TEMP/vyitec-url")/".insteadOf "https://code.vyitec.com/"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -119,9 +119,10 @@ jobs:
           VYITEC_USER: ${{ secrets.VYITEC_USER }}
           VYITEC_TOKEN: ${{ secrets.VYITEC_TOKEN }}
         run: |
-          cred_file="$RUNNER_TEMP/vyitec-creds"
-          printf 'https://%s:%s@code.vyitec.com\n' "$VYITEC_USER" "$VYITEC_TOKEN" > "$cred_file"
-          git config --global credential.helper "store --file=$cred_file"
+          # 用 URL 重写注入凭证（insteadOf），与 release-desktop.yml 保持一致；
+          # 不依赖 credential helper（Windows 预置 GCM 行为不可控）。
+          printf 'https://%s:%s@code.vyitec.com' "$VYITEC_USER" "$VYITEC_TOKEN" > "$RUNNER_TEMP/vyitec-url"
+          git config --global url."$(cat "$RUNNER_TEMP/vyitec-url")/".insteadOf "https://code.vyitec.com/"
 
       - name: Install dependencies
         if: steps.candidate.outputs.pending == 'true'


### PR DESCRIPTION
## 问题

#189 合并后重跑（tag `desktop-v0.1.7-nightly.20260908.39`），Windows job 依旧在同一位置失败：`Cannot prompt` + `could not read Username`。日志确认空 helper 重置已执行但未解决。

## 根因（比 #189 判断的更深一层）

Windows runner 的 GCM 不只挂在 system gitconfig 的 helper 链上——本地 Windows 复现证实：即使 global helper 链被空条目重置为仅剩 store，`git credential fill` 仍返回 GCM 缓存的凭证而非 store 文件内容。GCM 以 host provider 自动探测身份参与认证流程，不受 helper 链完全控制，无交互环境下探测超时/弹窗失败即中止。macOS/Linux runner 无 GCM 预置，因此只有 Windows 失败。

## 修复

彻底绕开 credential helper，改用 `url.insteadOf` URL 重写（三处：release macOS/Windows + scheduled 预检，保持一致）：

- git config 写入 `url."https://user:token@code.vyitec.com/".insteadOf "https://code.vyitec.com/"`
- 任何 git 调用（含 pnpm spawn 的 clone）访问该域时 URL 被原地改写为带凭证形式，不触发任何 helper/探测/prompt

## 本地验证（Windows，与 runner 同为 Git for Windows）

- `git clone https://code.vyitec.com/nexcore/everroom-openconnector.git` 以 insteadOf 配置克隆成功（GCM 预置环境，无任何 prompt）
- 对照组：helper 链方案在同一环境下 fill 返回错误凭证
