### PR TITLE
ci: 每日发布支持 auto 通道——检出 feat 提交自动发正式版

### DIFF
--- a/.github/workflows/scheduled-desktop-release.yml
+++ b/.github/workflows/scheduled-desktop-release.yml
@@ -9,9 +9,10 @@ on:
       channel:
         description: Release channel
         required: true
-        default: nightly
+        default: auto
         type: choice
         options:
+          - auto
           - nightly
           - alpha
 
@@ -48,6 +49,8 @@ jobs:
       NXCORE_BROWSER_EXTENSION_ID: ${{ vars.NXCORE_BROWSER_EXTENSION_ID }}
 
     steps:
+      # auto（每日默认）：扫上个正式 tag 以来的提交，含 feat: 则发正式版（latest），
+      # 否则发 nightly；nightly：强制夜间通道；alpha：从 alpha 分支发正式版。
       - name: Check out release branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -61,7 +64,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_CHANNEL: ${{ inputs.channel || 'nightly' }}
+          RELEASE_CHANNEL: ${{ inputs.channel || 'auto' }}
         run: |
           version="$(node -p "require('./apps/desktop/package.json').version")"
           [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
@@ -69,7 +72,33 @@ jobs:
             exit 1
           }
           git fetch origin 'refs/tags/desktop-v*:refs/tags/desktop-v*'
-          if [[ "$RELEASE_CHANNEL" == "alpha" ]]; then
+
+          # --- Determine channel (auto scans commits since last stable tag) ---
+          channel="$RELEASE_CHANNEL"
+          feat_commits=""
+          if [[ "$channel" == "auto" ]]; then
+            last_stable="$(git tag --list 'desktop-v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -Ev 'nightly|alpha|beta|rc' | head -n 1)"
+            if [[ -z "$last_stable" ]]; then
+              range="HEAD"
+            else
+              range="$last_stable..HEAD"
+            fi
+            # 仅匹配提交标题（%s）的 conventional feat 前缀，避免正文行误命中。
+            feat_commits="$(git log --no-merges --format='%h %s' "$range" | grep -Ei '^[0-9a-f]{7,40} feat(\([^)]*\))?!?:' || true)"
+
+            stable_tag="desktop-v$version"
+            if [[ -n "$feat_commits" ]] && ! git show-ref --verify --quiet "refs/tags/$stable_tag"; then
+              channel="stable"
+              echo "::notice::feat commits detected since ${last_stable:-beginning}: publishing stable $stable_tag"
+              echo "$feat_commits" | head -n 5 | sed 's/^/  /'
+            elif [[ -n "$feat_commits" ]] && git show-ref --verify --quiet "refs/tags/$stable_tag"; then
+              echo "::warning::feat commits detected but $stable_tag already exists; falling back to nightly. Bump the desktop version to publish a stable release."
+              echo "feat-pending=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+          # --- Resolve tag per channel ---
+          if [[ "$channel" == "stable" || "$channel" == "alpha" ]]; then
             tag="desktop-v$version"
             if git show-ref --verify --quiet "refs/tags/$tag"; then
               test "$(git rev-list -n 1 "$tag")" = "$(git rev-parse HEAD)" || {
@@ -191,6 +220,25 @@ jobs:
           分支：${{ inputs.channel == 'alpha' && 'alpha' || 'dev' }}
           提交：$(git log -1 --pretty='%h %s (%an)')
           日志：https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          payload="$(jq -n --arg text "$message" '{msg_type:"text",content:{text:$text}}')"
+          curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$FEISHU_WEBHOOK_URL" >/dev/null
+
+      - name: Notify Feishu when stable falls back to nightly
+        if: steps.candidate.outputs.pending == 'true' && steps.candidate.outputs.feat-pending == 'true'
+        shell: bash
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+        run: |
+          if [[ -z "$FEISHU_WEBHOOK_URL" ]]; then
+            echo "::warning::FEISHU_RELEASE_WEBHOOK is not configured; skipping notification."
+            exit 0
+          fi
+          version="$(node -p "require('./apps/desktop/package.json').version")"
+          message="EverRoom 检出 feat 提交但版本 $version 已发布正式版，本次降级为 nightly。
+          请在合入 feat 后顺手升级 apps/desktop/package.json 版本号，次日将自动补发正式版。"
           payload="$(jq -n --arg text "$message" '{msg_type:"text",content:{text:$text}}')"
           curl --fail --silent --show-error \
             -H 'Content-Type: application/json' \


### PR DESCRIPTION
## 概述

发布通道改为**内容驱动**：每日自动检查时扫描上个正式 tag 以来的提交，含 `feat:` 则自动发正式版（latest），否则照旧发 nightly。手动 dispatch 可强制 nightly；alpha 通道保留不变。

## 通道规则

| 触发 | 判定 | 产物 |
|------|------|------|
| 每日 cron（auto 默认） | `上个正式tag..HEAD` 含 `feat:` 提交 且 版本未发布过 | 正式版 `desktop-vX.Y.Z`（latest） |
| 每日 cron（auto 默认） | 无 feat 提交 | nightly `-nightly.日期.序号`（prerelease） |
| 每日 cron（auto 默认） | 有 feat 但该版本已发过正式版 | **降级发 nightly + 飞书提醒 bump 版本**，次日自动补发 |
| dispatch channel=nightly | 强制 | nightly |
| dispatch channel=alpha | 强制，从 alpha 分支 | 正式版 |

## 实现要点

- **feat 识别**：`git log --no-merges --format='%h %s'` 后正则 `^[0-9a-f]{7,40} feat(\([^)]*\))?!?:`——只匹配提交标题的 conventional feat 前缀（含 scope、breaking `!`），排除 merge commit、正文行误命中、`feature:`/`fixfeat` 等误报
- **last stable tag**：`desktop-vX.Y.Z` 格式、排除 nightly/alpha/beta/rc 后缀，version 排序取最新
- **降级自愈**：版本冲突不失败，发 nightly 兜底；因 feat 扫描基准是上个正式 tag（不随 nightly 移动），版本 bump 合入后次日自动补发正式版
- **发版动作为既有逻辑复用**：`release-desktop.yml` 零改动——tag 无 `-nightly.` 后缀即 `--latest` 正式版

## 约定（写给后续 PR 作者）

**feat PR 请顺手 bump `apps/desktop/package.json` 版本号**（至少 patch +1），否则正式版会降级为 nightly 并收到飞书提醒。

## 验证

本地以真实仓库数据模拟：last_stable 解析为 `desktop-v0.1.6`；`desktop-v0.1.6..origin/dev` 共 114 个非 merge 提交，feat 正则正确命中 10+ 条（章节刻度线、飞书/Notion 批量导入等）且无正文误报。当前 dev 若明日 cron 触发将发布 `desktop-v0.1.7` 正式版（0.1.7 无正式 tag）。

## 部署提醒

GitHub cron 只执行**默认分支（main）上的 workflow 文件**。本 PR 合入 dev 后，dispatch 立即可用；每日自动触发需等本文件同步到 main（dev→main 合并或单独 cherry-pick）后生效。
