### PR TITLE
feat(ci): 飞书消息卡片通知（Issue 新建 / PR 新建与合并 / 版本发布）

### DIFF
--- a/.github/actions/feishu-card/action.yml
+++ b/.github/actions/feishu-card/action.yml
@@ -1,0 +1,103 @@
+name: 'Send Feishu card'
+description: 'Assemble and send an interactive message card to a Feishu custom bot webhook.'
+
+inputs:
+  webhook-url:
+    description: 'Feishu bot webhook URL.'
+    required: true
+  template:
+    description: 'Card color template: blue, green, red, grey, or turquoise.'
+    required: true
+  title:
+    description: 'Card header title (plain text).'
+    required: true
+  body:
+    description: 'Card body content in lark_md, multiple lines allowed. Empty to omit the body element.'
+    required: false
+    default: ''
+  buttons:
+    description: 'JSON array of {"text": "...", "url": "...", "type": "primary|default"}. Empty to omit buttons.'
+    required: false
+    default: ''
+  note:
+    description: 'Grey note line shown at the card bottom. Empty to omit.'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Send Feishu card
+      shell: bash
+      env:
+        FEISHU_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        CARD_TEMPLATE: ${{ inputs.template }}
+        CARD_TITLE: ${{ inputs.title }}
+        CARD_BODY: ${{ inputs.body }}
+        CARD_BUTTONS: ${{ inputs.buttons }}
+        CARD_NOTE: ${{ inputs.note }}
+      run: |
+        if [[ -z "$FEISHU_WEBHOOK_URL" ]]; then
+          echo "::warning::Feishu webhook URL is not configured; skipping notification."
+          exit 0
+        fi
+
+        case "$CARD_TEMPLATE" in
+          blue|green|red|grey|turquoise) template="$CARD_TEMPLATE" ;;
+          *) echo "Unknown card template: $CARD_TEMPLATE" >&2; exit 1 ;;
+        esac
+
+        declare -a elements=()
+        if [[ -n "$CARD_BODY" ]]; then
+          body_json="$(jq -Rn --arg md "$CARD_BODY" '{tag:"div", text:{tag:"lark_md", content:$md}}')"
+          elements+=("$body_json")
+        fi
+        if [[ -n "$CARD_BUTTONS" ]]; then
+          echo "$CARD_BUTTONS" | jq -e 'type == "array"' >/dev/null || {
+            echo "buttons must be a JSON array" >&2; exit 1;
+          }
+          # One action element holding all buttons so they render in a row.
+          actions_json="$(jq -nc --argjson acts "$CARD_BUTTONS" '{
+            tag:"action",
+            actions:[$acts[] | {
+              tag:"button",
+              text:{tag:"plain_text", content:.text},
+              type:(.type // "default"),
+              url:.url
+            }]
+          }')"
+          elements+=("$actions_json")
+        fi
+        if [[ -n "$CARD_NOTE" ]]; then
+          # Legacy card schema: note.content must be a plain string.
+          note_json="$(jq -Rn --arg note "$CARD_NOTE" '{tag:"note", content:$note}')"
+          elements+=("$note_json")
+        fi
+
+        header_json="$(jq -Rn --arg title "$CARD_TITLE" '{
+          title:{tag:"plain_text", content:$title}
+        }')"
+        # Elements may be objects (markdown/note) or arrays (button groups);
+        # flatten everything into a single card elements array.
+        all_elements="$(printf '%s\n' "${elements[@]}" | jq -sc '[ .[] | if type == "array" then .[] else . end ]')"
+        payload="$(jq -nc \
+          --arg template "$template" \
+          --argjson header "$header_json" \
+          --argjson elements "$all_elements" '{
+            msg_type:"interactive",
+            card:{
+              config:{wide_markdown_mode:true},
+              header:{template:$template, title:($header.title)},
+              elements:$elements
+            }
+          }')"
+
+        response="$(curl --fail --silent --show-error \
+          -H 'Content-Type: application/json' \
+          --data "$payload" \
+          "$FEISHU_WEBHOOK_URL")"
+        code="$(jq -r '.code // .StatusCode // -1' <<< "$response")"
+        test "$code" = "0" || {
+          echo "Feishu rejected the card with code $code" >&2
+          exit 1
+        }

--- a/.github/workflows/notify-issue-opened.yml
+++ b/.github/workflows/notify-issue-opened.yml
@@ -1,0 +1,88 @@
+name: Notify Feishu when issue is opened
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to preview the notification for
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: notify-issue-opened
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    # Skip issues created by the Feishu -> GitHub bridge bot to avoid an
+    # echo loop: Feishu message creates the issue, which would notify the
+    # same Feishu group again.
+    if: github.event_name == 'workflow_dispatch' || github.event.issue.user.login != 'github-actions[bot]'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out default branch
+        # Local composite action requires a checkout.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve issue
+        id: issue
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          # workflow_dispatch has no issue in the payload; fetch it by number.
+          script: |
+            let issue = context.payload.issue;
+            if (!issue && context.payload.inputs?.issue_number) {
+              const { data } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(context.payload.inputs.issue_number),
+              });
+              issue = data;
+            }
+            if (!issue || issue.pull_request) {
+              core.setFailed('Issue not found or is a pull request.');
+              return;
+            }
+            core.setOutput('title', issue.title);
+            core.setOutput('url', issue.html_url);
+            core.setOutput('author', issue.user.login);
+            core.setOutput('number', issue.number);
+
+            const labels = issue.labels.map((l) => l.name).filter(Boolean);
+            core.setOutput('labels', labels.join(' · '));
+
+            const body = String(issue.body ?? '').trim();
+            const text = body
+              .replace(/<!--[\s\S]*?-->/g, '')
+              .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+              .replace(/\[([^\]]*)\]\(([^)]*)\)/g, '$1 ($2)')
+              .replace(/[#*`>]/g, '')
+              .replace(/\r/g, '')
+              .replace(/\n{2,}/g, '\n')
+              .trim();
+            const summary = text.length > 200 ? `${text.slice(0, 200)}…` : text;
+            core.setOutput('summary', summary);
+
+      - name: Notify Feishu
+        uses: ./.github/actions/feishu-card
+        with:
+          webhook-url: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          template: blue
+          title: 🐛 新 Issue #${{ steps.issue.outputs.number }}
+          body: |
+            **${{ steps.issue.outputs.title }}**
+
+            提交人：${{ steps.issue.outputs.author }}
+            ${{ steps.issue.outputs.labels && format('标签：{0}', steps.issue.outputs.labels) || '' }}
+
+            ${{ steps.issue.outputs.summary }}
+          buttons: '[{"text":"查看 Issue","url":"${{ steps.issue.outputs.url }}","type":"primary"}]'
+          note: ${{ github.repository }}

--- a/.github/workflows/notify-pr-opened.yml
+++ b/.github/workflows/notify-pr-opened.yml
@@ -1,13 +1,12 @@
-name: Notify Feishu when pull request is merged
+name: Notify Feishu when pull request is opened
 
 on:
   pull_request_target:
-    branches: [main]
-    types: [closed]
+    types: [opened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
-        description: Merged pull request number to preview the notification for
+        description: Pull request number to preview the notification for
         required: true
         type: string
 
@@ -16,12 +15,14 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: notify-pr-merged
+  group: notify-pr-opened
   cancel-in-progress: false
 
 jobs:
   notify:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    # Draft PRs are silent on "opened"; they notify once marked ready for
+    # review via the ready_for_review event.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft != true
     runs-on: ubuntu-24.04
     steps:
       - name: Check out base branch
@@ -36,7 +37,8 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           # workflow_dispatch has no PR in the payload; fetch it by number.
-          # Restrict to merged PRs so the preview cannot report an open PR.
+          # The webhook payload lacks additions/deletions, so the REST API
+          # is always used to fetch the diff stats.
           script: |
             let number = context.payload.pull_request?.number
               ?? Number(context.payload.inputs?.pr_number);
@@ -49,30 +51,34 @@ jobs:
               repo: context.repo.repo,
               pull_number: number,
             });
-            if (!pr.merged) {
-              core.setFailed('Pull request is not merged.');
+            if (pr.draft) {
+              core.notice('Pull request is a draft; skipping notification.');
+              core.setOutput('skip', 'true');
               return;
             }
+            core.setOutput('skip', 'false');
             core.setOutput('title', pr.title);
             core.setOutput('url', pr.html_url);
             core.setOutput('author', pr.user.login);
             core.setOutput('number', pr.number);
-            core.setOutput('merged_by', pr.merged_by?.login ?? 'unknown');
             core.setOutput('head', pr.head.ref);
             core.setOutput('base', pr.base.ref);
-            core.setOutput('merge_commit_sha', pr.merge_commit_sha?.slice(0, 7) ?? '');
+            core.setOutput('additions', pr.additions);
+            core.setOutput('deletions', pr.deletions);
+            core.setOutput('files', pr.changed_files);
 
       - name: Notify Feishu
+        if: steps.pr.outputs.skip != 'true'
         uses: ./.github/actions/feishu-card
         with:
           webhook-url: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
-          template: green
-          title: ✅ PR #${{ steps.pr.outputs.number }} 已合并进 ${{ steps.pr.outputs.base }}
+          template: turquoise
+          title: 🔀 新 PR #${{ steps.pr.outputs.number }} 请求评审
           body: |
             **${{ steps.pr.outputs.title }}**
 
-            作者：${{ steps.pr.outputs.author }} · 合并人：${{ steps.pr.outputs.merged_by }}
+            作者：${{ steps.pr.outputs.author }}
             分支：${{ steps.pr.outputs.head }} -> ${{ steps.pr.outputs.base }}
-            squash 提交：${{ steps.pr.outputs.merge_commit_sha }}
-          buttons: '[{"text":"查看 PR","url":"${{ steps.pr.outputs.url }}","type":"primary"}]'
+            规模：+${{ steps.pr.outputs.additions }} / −${{ steps.pr.outputs.deletions }} · ${{ steps.pr.outputs.files }} 个文件
+          buttons: '[{"text":"开始评审","url":"${{ steps.pr.outputs.url }}","type":"primary"}]'
           note: ${{ github.repository }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -434,45 +434,69 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Notify Feishu
+      - name: Collect release summary
+        id: summary
         shell: bash
         env:
-          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
           PUBLISH_RESULT: ${{ needs.publish.result }}
         run: |
-          if [[ -z "$FEISHU_WEBHOOK_URL" ]]; then
-            echo "::warning::FEISHU_RELEASE_WEBHOOK is not configured; skipping notification."
-            exit 0
-          fi
+          version="${GITHUB_REF_NAME#desktop-v}"
+          version="${version%%-*}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
           previous_tag="$(git describe --tags --match 'desktop-v*' --abbrev=0 "$GITHUB_SHA^" 2>/dev/null || true)"
           if [[ -n "$previous_tag" ]]; then
-            commits="$(git log --no-merges --pretty='- %h %s (%an)' "$previous_tag..$GITHUB_SHA" -n 20)"
+            commits="$(git log --no-merges --pretty='- %h %s (%an)' "$previous_tag..$GITHUB_SHA" -n 10)"
           else
-            commits="$(git log --no-merges --pretty='- %h %s (%an)' "$GITHUB_SHA" -n 20)"
+            commits="$(git log --no-merges --pretty='- %h %s (%an)' "$GITHUB_SHA" -n 10)"
           fi
           [[ -n "$commits" ]] || commits="- 本版本仅包含合并提交"
+          {
+            echo "commits<<RELEASE_COMMITS_EOF"
+            echo "$commits"
+            echo "RELEASE_COMMITS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
+          repo_url="https://github.com/$GITHUB_REPOSITORY"
           if [[ "$PUBLISH_RESULT" == "success" ]]; then
-            status="成功"
-            target="https://github.com/$GITHUB_REPOSITORY/releases/tag/$GITHUB_REF_NAME"
+            buttons="$(jq -nc --arg dmg "$repo_url/releases/download/$GITHUB_REF_NAME/EverRoom-$version-arm64.dmg" \
+              --arg exe "$repo_url/releases/download/$GITHUB_REF_NAME/EverRoom-$version-windows-x64.exe" \
+              --arg rel "$repo_url/releases/tag/$GITHUB_REF_NAME" '[
+                {text:"⬇ macOS .dmg", url:$dmg, type:"default"},
+                {text:"⬇ Windows .exe", url:$exe, type:"default"},
+                {text:"查看 Release", url:$rel, type:"primary"}
+              ]')"
           else
-            status="失败"
-            target="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            buttons="$(jq -nc --arg log "$repo_url/actions/runs/$GITHUB_RUN_ID" '[
+              {text:"查看构建日志", url:$log, type:"primary"}
+            ]')"
           fi
+          echo "buttons=$buttons" >> "$GITHUB_OUTPUT"
 
-          message="EverRoom 桌面端发布$status
-          版本：$GITHUB_REF_NAME
-          提交：
-          $commits
-          地址：$target"
-          payload="$(jq -n --arg text "$message" '{msg_type:"text",content:{text:$text}}')"
-          response="$(curl --fail --silent --show-error \
-            -H 'Content-Type: application/json' \
-            --data "$payload" \
-            "$FEISHU_WEBHOOK_URL")"
-          code="$(jq -r '.code // .StatusCode // -1' <<< "$response")"
-          test "$code" = "0" || {
-            echo "Feishu rejected the notification with code $code" >&2
-            exit 1
-          }
+      - name: Notify Feishu (success)
+        if: needs.publish.result == 'success'
+        uses: ./.github/actions/feishu-card
+        with:
+          webhook-url: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          template: green
+          title: 🚀 ${{ github.ref_name }} 发布成功
+          body: |
+            **自上版以来的提交：**
+            ${{ steps.summary.outputs.commits }}
+          buttons: ${{ steps.summary.outputs.buttons }}
+          note: ${{ github.repository }}
+
+      - name: Notify Feishu (failure)
+        if: needs.publish.result != 'success'
+        uses: ./.github/actions/feishu-card
+        with:
+          webhook-url: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          template: red
+          title: 🚀 ${{ github.ref_name }} 发布失败
+          body: |
+            构建或发布未成功，请查看日志排查。
+
+            **涉及的提交：**
+            ${{ steps.summary.outputs.commits }}
+          buttons: ${{ steps.summary.outputs.buttons }}
+          note: ${{ github.repository }}


### PR DESCRIPTION
## 概述

- 新增可复用的 composite action `.github/actions/feishu-card`：组装并向飞书机器人 webhook 发送交互式消息卡片（彩色标题栏 + markdown 正文 + 按钮组 + 底部备注），四条通知共用一个发送出口
- 新增 **Issue 新建**通知（蓝色卡片）——跳过 `github-actions[bot]` 创建的 Issue，避免与「飞书 → GitHub 建 Issue」通道（`feishu-issue-create.yml`）形成回环：群消息建 Issue 后又通知回同一个群
- 新增 **PR 新建 / 标记 ready**通知（靛蓝色卡片），覆盖所有目标分支——Draft PR 静默，标记 ready 后才通知；通过 REST API 获取 `+新增 / −删除 · 变更文件数` 规模信息
- **PR 合并**通知由纯文本升级为绿色卡片
- **桌面端发布**通知升级：成功发绿色卡片（含 `.dmg` / `.exe` 直接下载按钮 + 「查看 Release」）；失败发红色卡片，按钮直达构建日志

## 卡片设计

| 事件 | 颜色 | 关键信息 | 主按钮 |
|---|---|---|---|
| 新 Issue | 蓝 | 标题、提交人、标签、200 字摘要 | 查看 Issue |
| 新 PR 请求评审 | 靛蓝 | 标题、作者、分支、+/− 变更规模 | 开始评审 |
| PR 已合并 | 绿 | 标题、作者 · 合并人、squash 提交 | 查看 PR |
| 发布成功 | 绿 | 自上版以来最多 10 条提交 | ⬇ macOS / ⬇ Windows / 查看 Release |
| 发布失败 | 红 | 失败提示 + 涉及提交 | 查看构建日志 |

## 说明

- 每个通知 workflow 均支持 `workflow_dispatch` 手动触发（输入 Issue/PR 编号即可预览卡片，无需等真实事件）
- webhook 仍读取 `secrets.FEISHU_RELEASE_WEBHOOK`，仓库中不硬编码 URL
- `pull_request_target` 工作流只 checkout base 分支（绝不执行 PR 代码），保证安全
- `scheduled-desktop-release.yml` 中还有两条纯文本告警（每日预检失败 / 正式版降级 nightly），不在本次范围内，后续可跟进
- 已在本地验证：actionlint + YAML 解析 + payload 结构干跑 + 向 webhook 真实发送一张测试卡片（返回 code 0）