### PR TITLE
fix: 移除 extraResources 平台段重复的 lark-cli/ntn，修复 Windows 打包 EBUSY

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -226,20 +226,6 @@
             "LICENSE",
             "prebuilds/darwin-arm64.node"
           ]
-        },
-        {
-          "from": "build/ntn",
-          "to": "ntn",
-          "filter": [
-            "**/*"
-          ]
-        },
-        {
-          "from": "build/lark-cli",
-          "to": "lark-cli",
-          "filter": [
-            "**/*"
-          ]
         }
       ]
     },
@@ -263,13 +249,6 @@
             "package.json",
             "LICENSE",
             "prebuilds/win32-x64.node"
-          ]
-        },
-        {
-          "from": "build/lark-cli",
-          "to": "lark-cli",
-          "filter": [
-            "**/*"
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- Windows nightly（desktop-v0.1.7-nightly.20260910.45）打包失败：`EBUSY: resource busy or locked, copyfile lark-cli.exe`
- 根因：electron-builder 把平台段 `extraResources` 与根段**合并**而非替换。`build/lark-cli` 同时声明在根段和 `win` 段，两个 matcher **并发复制**同一个 49MB exe 到相同目标，第二个撞文件锁失败（macOS 无共享冲突语义所以 mac job 侥幸通过，但 mac 段的 ntn/lark-cli 重复同样造成双写）
- 修复：删除 `win.extraResources` 的 `build/lark-cli`、`mac.extraResources` 的 `build/ntn` 和 `build/lark-cli`（根段已含全部三个运行时，产物内容不变）

## Test plan
- [x] 本地 Windows 用重复配置复现 electron-builder `--dir` 打包：lark-cli 第二次复制稳定报同款 EBUSY（tmp/repro-ebusy.log，ntn 双写时签名日志出现两次也证实双复制）
- [x] 本地 Windows 用修复后配置打包：exit=0，每个 exe 仅签名一次，`resources/lark-cli|ntn` 产物齐全
- [ ] 触发 dev nightly 走完整 CI 验证（nsis + 内容审计）