### PR TITLE
fix(desktop): stop sidebar chat autoscroll from fighting user scroll

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent/AgentChatView.test.tsx
+++ b/apps/desktop/src/renderer/src/components/agent/AgentChatView.test.tsx
@@ -50,6 +50,7 @@ vi.mock('../../i18n/LocaleContext', async (importOriginal) => {
 })
 
 import { AgentChatView } from './AgentChatView'
+import type { DisplayAgentMessage } from './useAgentSession'
 
 function pendingIntent(targetCapability: 'document.edit' | 'document.continue'): PendingAgentIntent {
   return {
@@ -219,6 +220,149 @@ describe('AgentChatView', () => {
     expect(onNotificationRunLocated).toHaveBeenCalledWith('notification-1')
     expect(renderer.root.findByProps({ 'data-agent-message-id': 'assistant-2' }).props['data-notification-target'])
       .toBe('true')
+    act(() => renderer.unmount())
+  })
+
+  it('stops forcing the conversation to the bottom once the user scrolls up', async () => {
+    const conversationNode = {
+      clientHeight: 400,
+      scrollHeight: 800,
+      scrollTop: 0,
+      querySelectorAll: () => [],
+    }
+    const message = (id: string, content: string): DisplayAgentMessage => ({
+      id,
+      sessionId: 'session-1',
+      runId: 'run-1',
+      role: 'assistant',
+      content,
+      createdAt: '2026-08-20T00:00:01.000Z',
+    })
+    const renderView = (messages: DisplayAgentMessage[]) => (
+      <AgentChatView
+        activeDocument={null}
+        activeRunId="run-1"
+        agentIdByRun={{}}
+        agentNamesById={{}}
+        activityByRun={{}}
+        availableRooms={[]}
+        composer={null}
+        currentSessionId="session-1"
+        draftHasContent={false}
+        error={null}
+        loading={false}
+        messages={messages}
+        onOpenSessionLink={vi.fn()}
+        onRejectDocumentIntent={vi.fn()}
+        onRetryPrompt={vi.fn()}
+        onSelectDocument={vi.fn()}
+        onSelectPrompt={vi.fn()}
+        onSelectRoom={vi.fn().mockResolvedValue(undefined)}
+        pendingNavigationByRun={{}}
+        runCompletedAtByRun={{}}
+        runStartedAtByRun={{}}
+        scopeReady
+        sessionLinks={[]}
+        submitting={false}
+        toolCallsByRun={{}}
+      />
+    )
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(renderView([message('assistant-1', '第一段回复')]), {
+        createNodeMock: (element) => element.props.className === 'agent-conversation'
+          ? conversationNode
+          : {},
+      })
+    })
+    // 初始渲染：默认贴底，自动滚动应把 scrollTop 拉到 scrollHeight。
+    expect(conversationNode.scrollTop).toBe(800)
+
+    // 用户向上滚动，离开底部。
+    conversationNode.scrollTop = 100
+    await act(async () => {
+      renderer.root.findByProps({ className: 'agent-conversation' }).props.onScroll()
+    })
+
+    // 流式更新继续到达，但不应再强制拉回底部。
+    conversationNode.scrollTop = 100
+    await act(async () => {
+      renderer.update(renderView([
+        message('assistant-1', '第一段回复'),
+        message('assistant-2', '第二段流式输出'),
+      ]))
+    })
+    expect(conversationNode.scrollTop).toBe(100)
+
+    act(() => renderer.unmount())
+  })
+
+  it('keeps following the newest content while the user stays at the bottom', async () => {
+    const conversationNode = {
+      clientHeight: 400,
+      scrollHeight: 800,
+      scrollTop: 0,
+      querySelectorAll: () => [],
+    }
+    const message = (id: string, content: string): DisplayAgentMessage => ({
+      id,
+      sessionId: 'session-1',
+      runId: 'run-1',
+      role: 'assistant',
+      content,
+      createdAt: '2026-08-20T00:00:01.000Z',
+    })
+    const renderView = (messages: DisplayAgentMessage[], currentSessionId = 'session-1') => (
+      <AgentChatView
+        activeDocument={null}
+        activeRunId="run-1"
+        agentIdByRun={{}}
+        agentNamesById={{}}
+        activityByRun={{}}
+        availableRooms={[]}
+        composer={null}
+        currentSessionId={currentSessionId}
+        draftHasContent={false}
+        error={null}
+        loading={false}
+        messages={messages}
+        onOpenSessionLink={vi.fn()}
+        onRejectDocumentIntent={vi.fn()}
+        onRetryPrompt={vi.fn()}
+        onSelectDocument={vi.fn()}
+        onSelectPrompt={vi.fn()}
+        onSelectRoom={vi.fn().mockResolvedValue(undefined)}
+        pendingNavigationByRun={{}}
+        runCompletedAtByRun={{}}
+        runStartedAtByRun={{}}
+        scopeReady
+        sessionLinks={[]}
+        submitting={false}
+        toolCallsByRun={{}}
+      />
+    )
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(renderView([message('assistant-1', '第一段回复')]), {
+        createNodeMock: (element) => element.props.className === 'agent-conversation'
+          ? conversationNode
+          : {},
+      })
+    })
+    expect(conversationNode.scrollTop).toBe(800)
+
+    // 贴底状态下内容增长（scrollHeight 变大），自动滚动应继续贴底。
+    conversationNode.scrollHeight = 1200
+    await act(async () => {
+      renderer.update(renderView([
+        message('assistant-1', '第一段回复'),
+        message('assistant-2', '第二段流式输出'),
+      ]))
+    })
+    expect(conversationNode.scrollTop).toBe(1200)
+
     act(() => renderer.unmount())
   })
 

--- a/apps/desktop/src/renderer/src/components/agent/AgentChatView.tsx
+++ b/apps/desktop/src/renderer/src/components/agent/AgentChatView.tsx
@@ -390,6 +390,7 @@ export function AgentChatView({
   const handledDocumentSelectionsRef = useRef(new Set<string>())
   const { documentsByRoom } = useRoomDocumentsState()
   const conversationRef = useRef<HTMLDivElement>(null)
+  const stickToBottomRef = useRef(true)
   const hasConversation = messages.length > 0 || sessionLinks.length > 0 || pendingApprovals.length > 0
     || Boolean(activeRunId) || Boolean(error)
   const confirmedEmpty = scopeReady && !hasConversation
@@ -541,9 +542,20 @@ export function AgentChatView({
     }
   }, [])
 
+  // 会话切换后重置为贴底状态并强制滚动到底一次，避免沿用上一会话的滚动位置。
+  const previousSessionRef = useRef(currentSessionId)
+  useEffect(() => {
+    if (previousSessionRef.current === currentSessionId) return
+    previousSessionRef.current = currentSessionId
+    stickToBottomRef.current = true
+    const element = conversationRef.current
+    if (element) element.scrollTop = element.scrollHeight
+  }, [currentSessionId])
+
   useEffect(() => {
     const element = conversationRef.current
     if (!element || notificationTargetMessageId) return
+    if (!stickToBottomRef.current) return
     element.scrollTop = element.scrollHeight
   }, [activeRunId, linkedRun.messages, linkedRun.reasoning, linkedRun.tools, messages, notificationTargetMessageId, pendingApprovals, toolCallsByRun])
 
@@ -651,7 +663,16 @@ export function AgentChatView({
       }}
     >
       {emptyLayout ? <div className="agent-chat-empty-heading"><h2>{t('surface:agentChat.startANewConversation')}</h2></div> : null}
-      <div ref={conversationRef} className="agent-conversation" aria-live="polite">
+      <div
+        ref={conversationRef}
+        className="agent-conversation"
+        aria-live="polite"
+        onScroll={() => {
+          const element = conversationRef.current
+          if (!element) return
+          stickToBottomRef.current = element.scrollHeight - element.scrollTop - element.clientHeight < 40
+        }}
+      >
           {incomingLink ? (
             <>
               <SessionReference link={incomingLink} onOpen={() => onOpenSessionLink(incomingLink)} />


### PR DESCRIPTION
## Summary

Fixes #199（侧栏 AI 对话输出截断后页面滚动卡住）。

根因：`AgentChatView.tsx` 的自动滚动 `useEffect` 在每次流式更新（`messages` / `linkedRun.messages/reasoning/tools` / `toolCallsByRun` 等变化）时无条件执行 `element.scrollTop = element.scrollHeight`。AI 输出期间这些依赖高频变化，每次都把视口拽回底部，与用户手动滚动互相打架——表现为"卡在某个滚动高度无法下滚、上滚被反复拉回"；发新消息 / 等 Agent 执行完 / 切换会话后流式更新停止，打架消失故可恢复。

修复：stick-to-bottom 模式（最小改动，+23/-1）：

- `stickToBottomRef` 跟踪贴底状态（距底 < 40px），`onScroll` 更新，ref 存储避免重渲染；
- 自动滚动 effect 仅在贴底时执行，原有的 `notificationTargetMessageId` 跳过逻辑不变；
- 会话切换（`currentSessionId` 变化）重置为贴底并强制滚底一次；
- 其余行为（通知定位 `scrollIntoView`、空态布局等）不动。

## Test plan

- [x] `pnpm --filter @nxcore/desktop typecheck` 通过
- [x] 新增 2 个用例（`AgentChatView.test.tsx`，react-test-renderer + `createNodeMock` 模拟滚动容器）：
  - 用户上滚后流式更新不再强制拉底（scrollTop 保持 100）
  - 贴底时内容增长继续跟随（scrollTop 跟到 1200）
- [x] 反向验证：仅保留测试、还原源码时新用例如预期失败（1 failed | 5 passed），证明用例真实锁定 bug 行为
- [x] 回归：改动前后 desktop 全量测试失败集一致（预存在的环境类失败不变），未修改任何既有断言
