### PR TITLE
fix: Sentry 观测补强——网关输出上远端、日志细节不再丢失

### DIFF
--- a/apps/desktop/src/main/gateway/gateway-supervisor.ts
+++ b/apps/desktop/src/main/gateway/gateway-supervisor.ts
@@ -7,6 +7,7 @@ import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'node:c
 import { app } from 'electron'
 import type { GatewayStatus } from '../../shared/sources'
 import { createLoggedHttpClient } from '../network/http-client'
+import { captureSentryLog } from '../monitoring/sentry'
 import { forgetProcessRecord, registerProcessRecord } from '../process-cleanup'
 
 interface GatewayManifest {
@@ -39,20 +40,46 @@ function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
 
+const GATEWAY_REMOTE_LOG_WINDOW_MS = 60_000
+const GATEWAY_REMOTE_LOG_LIMIT = 30
+const gatewayRemoteLogTimes: number[] = []
+
+/** 网关子进程的输出只进本地控制台；stderr/error 行抽样上报远端，卡死/崩溃时
+ *  Pro 用户排障才有网关侧现场（本地日志文件拿不到）。限频防雪崩刷屏。 */
+export function captureGatewayOutputRemote(label: string, stream: 'stdout' | 'stderr', line: string, now = Date.now()): void {
+  const errorLike = /\b(error|fatal|unhandled|uncaught)\b/i.test(line)
+  if (stream === 'stdout' && !errorLike) return
+  while (gatewayRemoteLogTimes.length > 0 && now - gatewayRemoteLogTimes[0]! > GATEWAY_REMOTE_LOG_WINDOW_MS) {
+    gatewayRemoteLogTimes.shift()
+  }
+  if (gatewayRemoteLogTimes.length >= GATEWAY_REMOTE_LOG_LIMIT) return
+  gatewayRemoteLogTimes.push(now)
+  captureSentryLog(`gateway-${label}`, errorLike ? 'error' : 'warn', {
+    event: 'gateway.output',
+    stream,
+    line: line.slice(0, 2000),
+  })
+}
+
 function forwardGatewayOutput(
   stream: NodeJS.ReadableStream,
   destination: NodeJS.WriteStream,
   label: string,
+  streamName: 'stdout' | 'stderr',
 ): void {
   let pending = ''
+  const emit = (line: string): void => {
+    destination.write(`[${label}] ${line}\n`)
+    captureGatewayOutputRemote(label, streamName, line)
+  }
   stream.on('data', (chunk: string) => {
     pending += chunk
     const lines = pending.split(/\r?\n/)
     pending = lines.pop() ?? ''
-    for (const line of lines) destination.write(`[${label}] ${line}\n`)
+    for (const line of lines) emit(line)
   })
   stream.on('end', () => {
-    if (pending) destination.write(`[${label}] ${pending}\n`)
+    if (pending) emit(pending)
   })
 }
 
@@ -186,8 +213,8 @@ export class GatewaySupervisor {
 
     child.stdout.setEncoding('utf8')
     child.stderr.setEncoding('utf8')
-    forwardGatewayOutput(child.stdout, process.stdout, this.options.logLabel ?? 'gateway')
-    forwardGatewayOutput(child.stderr, process.stderr, this.options.logLabel ?? 'gateway')
+    forwardGatewayOutput(child.stdout, process.stdout, this.options.logLabel ?? 'gateway', 'stdout')
+    forwardGatewayOutput(child.stderr, process.stderr, this.options.logLabel ?? 'gateway', 'stderr')
     child.on('exit', (code, signal) => {
       this.child = null
       this.connection = null

--- a/apps/desktop/src/main/logging/desktop-logger.ts
+++ b/apps/desktop/src/main/logging/desktop-logger.ts
@@ -141,7 +141,14 @@ function installGlobalConsole(): void {
     const actualLevel: LogLevel = level === 'log' ? 'info' : level
     const [first, ...rest] = args
     const event = typeof first === 'string' ? first : 'console event'
-    const details = rest.length === 0 ? undefined : rest.length === 1 ? rest[0] : rest
+    // Error 直接 JSON 序列化只剩 {}；name/message/stack 拆开存，远端排障才有细节。
+    const serializeConsoleArg = (value: unknown): unknown =>
+      value instanceof Error
+        ? { name: value.name, message: value.message, stack: value.stack?.split('\n').slice(0, 10).join('\n') }
+        : value
+    const details = rest.length === 0 ? undefined
+      : rest.length === 1 ? serializeConsoleArg(rest[0])
+      : rest.map(serializeConsoleArg)
     const now = new Date()
     const payload = details === undefined ? { event } : { event, details }
     const threshold = desktopLogThreshold('console')

--- a/apps/desktop/src/main/monitoring/sentry.ts
+++ b/apps/desktop/src/main/monitoring/sentry.ts
@@ -52,7 +52,10 @@ export function configureSentry(version: string, packaged: boolean): void {
       sendDefaultPii: false,
       tracesSampleRate: 0,
       integrations: (defaults) => defaults.filter(
-        ({ name }) => name !== 'MainProcessSession' && name !== 'SentryMinidump',
+        // Console：desktop-logger 已带阈值/脱敏/模块标签捕获 console，SDK 自带的
+        // 无阈值版本会把轮询类 console.debug（对象参数）以每 5 秒一条的频率刷上
+        // 远端（线上曾积累 5 万条 "[object Object]"），故移除避免重复与刷屏。
+        ({ name }) => name !== 'MainProcessSession' && name !== 'SentryMinidump' && name !== 'Console',
       ),
       beforeBreadcrumb: (breadcrumb) => isRemoteDebugActive() ? redactSentryPayload(breadcrumb) : null,
       beforeSend: (event) => isRemoteDebugActive() ? redactSentryPayload(event) : null,

--- a/apps/desktop/src/main/monitoring/sentry.ts
+++ b/apps/desktop/src/main/monitoring/sentry.ts
@@ -52,10 +52,12 @@ export function configureSentry(version: string, packaged: boolean): void {
       sendDefaultPii: false,
       tracesSampleRate: 0,
       integrations: (defaults) => defaults.filter(
-        // Console：desktop-logger 已带阈值/脱敏/模块标签捕获 console，SDK 自带的
-        // 无阈值版本会把轮询类 console.debug（对象参数）以每 5 秒一条的频率刷上
-        // 远端（线上曾积累 5 万条 "[object Object]"），故移除避免重复与刷屏。
-        ({ name }) => name !== 'MainProcessSession' && name !== 'SentryMinidump' && name !== 'Console',
+        // ElectronNet：enableLogs 下它把每个 Electron 网络请求记成 info 日志，
+        // 轮询类请求曾 48 小时刷 5 万条垃圾（origin=auto.electron.net）。
+        // Console：desktop-logger 已带阈值/脱敏/模块标签捕获，SDK 自带版本无
+        // 阈值，会造成重复与刷屏。
+        ({ name }) => name !== 'MainProcessSession' && name !== 'SentryMinidump'
+          && name !== 'ElectronNet' && name !== 'Console',
       ),
       beforeBreadcrumb: (breadcrumb) => isRemoteDebugActive() ? redactSentryPayload(breadcrumb) : null,
       beforeSend: (event) => isRemoteDebugActive() ? redactSentryPayload(event) : null,

--- a/apps/desktop/src/main/network/http-client.ts
+++ b/apps/desktop/src/main/network/http-client.ts
@@ -91,13 +91,26 @@ const chromiumFetchAdapter: AxiosAdapter = async (config) => {
     headers.set(key, String(value))
   }
 
-  const response = await net.fetch(target.toString(), {
-    method: (config.method ?? 'get').toUpperCase(),
-    headers,
-    body: config.data === undefined ? undefined : await toFetchBody(config.data),
-    signal: requestSignal(config),
-    redirect: 'follow',
-  })
+  // 网络层失败（超时/断连）原生错误不带 config，错误日志里 url/method 会全部
+  // 丢失——包成 AxiosError 把 config 带回拦截器，排障才知道是哪个调用超时。
+  let response: Response
+  try {
+    response = await net.fetch(target.toString(), {
+      method: (config.method ?? 'get').toUpperCase(),
+      headers,
+      body: config.data === undefined ? undefined : await toFetchBody(config.data),
+      signal: requestSignal(config),
+      redirect: 'follow',
+    })
+  } catch (error) {
+    if (error instanceof AxiosError) throw error
+    const source = error instanceof Error ? error : new Error(String(error))
+    const rawCode = (source as { code?: unknown }).code
+    const code = typeof rawCode === 'string' && rawCode ? rawCode
+      : source.name !== 'Error' ? source.name
+      : undefined
+    throw new AxiosError(source.message, code, config)
+  }
 
   const responseType = config.responseType ?? 'json'
   let data: unknown

--- a/apps/desktop/src/main/transcription/processing-coordinator.ts
+++ b/apps/desktop/src/main/transcription/processing-coordinator.ts
@@ -15,6 +15,8 @@ import type { PrivateTranscriptionSyncService } from './private-transcription-sy
 import { summaryDetailMinimum } from './summary-quality'
 
 const POLL_INTERVAL_MS = 5_000
+const MAX_POLL_INTERVAL_MS = 60_000
+const MAX_FAILURE_STREAK = 4
 const LEASE_RENEW_INTERVAL_MS = 45_000
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
@@ -68,6 +70,7 @@ export class TranscriptionProcessingCoordinator {
   private running = false
   private stopped = true
   private timer: NodeJS.Timeout | null = null
+  private failureStreak = 0
   private registeredKey: string | null = null
 
   constructor(
@@ -116,11 +119,19 @@ export class TranscriptionProcessingCoordinator {
     this.running = true
     try {
       await this.processOne()
+      this.failureStreak = 0
     } catch (error) {
+      // 系统退化（网关阻塞/SaaS 超时）时以固定 5s 重试只会放大压力（线上曾
+      // 连刷 139 次失败），指数退避，成功后归零。
+      this.failureStreak = Math.min(this.failureStreak + 1, MAX_FAILURE_STREAK)
       console.warn('Background transcription processing tick failed.', error)
     } finally {
       this.running = false
-      if (!this.stopped) this.timer = setTimeout(() => void this.tick(), POLL_INTERVAL_MS)
+      if (!this.stopped) {
+        const delay = this.failureStreak === 0 ? POLL_INTERVAL_MS
+          : Math.min(POLL_INTERVAL_MS * 2 ** this.failureStreak, MAX_POLL_INTERVAL_MS)
+        this.timer = setTimeout(() => void this.tick(), delay)
+      }
     }
   }
 

--- a/apps/desktop/tests/desktop-logger.test.ts
+++ b/apps/desktop/tests/desktop-logger.test.ts
@@ -94,4 +94,19 @@ describe('desktop logger isolation', () => {
       { event: 'pipeline.failed' },
     )
   })
+
+  it('serializes Error console args with name, message and stack', () => {
+    sentryMocks.captureSentryLog.mockClear()
+
+    console.error('transcription tick failed', new Error('boom'))
+
+    expect(sentryMocks.captureSentryLog).toHaveBeenCalledWith('console', 'error', expect.objectContaining({
+      event: 'transcription tick failed',
+      details: expect.objectContaining({
+        name: 'Error',
+        message: 'boom',
+        stack: expect.any(String),
+      }),
+    }))
+  })
 })

--- a/apps/desktop/tests/gateway-supervisor.test.ts
+++ b/apps/desktop/tests/gateway-supervisor.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', () => ({
   app: {
@@ -13,7 +13,9 @@ vi.mock('electron', () => ({
 }))
 vi.mock('../src/main/monitoring/sentry', () => ({ captureSentryLog: vi.fn() }))
 
+import { captureSentryLog } from '../src/main/monitoring/sentry'
 import {
+  captureGatewayOutputRemote,
   GatewaySupervisor,
   type GatewayConnection,
 } from '../src/main/gateway/gateway-supervisor'
@@ -219,5 +221,40 @@ describe('GatewaySupervisor connection recovery', () => {
 
     await supervisor.shutdown()
     expect(supervisor.isRunning()).toBe(false)
+  })
+})
+
+describe('captureGatewayOutputRemote', () => {
+  const captureMock = vi.mocked(captureSentryLog)
+
+  beforeEach(() => {
+    captureMock.mockClear()
+  })
+
+  it('stdout 常规行不上报；error 关键字行与 stderr 行分别按 error/warn 上报', () => {
+    captureGatewayOutputRemote('gateway', 'stdout', 'hello routine line', 1_000)
+    captureGatewayOutputRemote('gateway', 'stdout', 'ERROR: sqlite locked', 1_001)
+    captureGatewayOutputRemote('gateway', 'stderr', 'plain stderr warning', 1_002)
+
+    expect(captureMock).toHaveBeenCalledTimes(2)
+    expect(captureMock).toHaveBeenNthCalledWith(1, 'gateway-gateway', 'error', expect.objectContaining({
+      event: 'gateway.output',
+      stream: 'stdout',
+      line: 'ERROR: sqlite locked',
+    }))
+    expect(captureMock).toHaveBeenNthCalledWith(2, 'gateway-gateway', 'warn', expect.objectContaining({
+      stream: 'stderr',
+    }))
+  })
+
+  it('每分钟限频 30 条，超出丢弃', () => {
+    const base = 100_000
+    for (let index = 0; index < 35; index += 1) {
+      captureGatewayOutputRemote('gateway', 'stderr', `line ${index}`, base + index * 100)
+    }
+    expect(captureMock).toHaveBeenCalledTimes(30)
+    expect(captureMock).toHaveBeenLastCalledWith('gateway-gateway', 'warn', expect.objectContaining({
+      line: 'line 29',
+    }))
   })
 })

--- a/apps/desktop/tests/http-client-adapter.test.ts
+++ b/apps/desktop/tests/http-client-adapter.test.ts
@@ -88,4 +88,25 @@ describe.skipIf(lan === null)('chromium fetch adapter（经 mock net.fetch）', 
     const response = await http.get(`http://${lan}:${String(port)}/v1/blob`, { responseType: 'arraybuffer' })
     expect(Buffer.from(response.data as ArrayBuffer)).toEqual(payload)
   })
+
+  it('网络层失败包装为 AxiosError 并保留 config（超时日志不丢 url/method）', async () => {
+    const http = createLoggedHttpClient('adapter-test')
+    const netMock = (await import('electron')).net as unknown as {
+      fetch: (url: string, init?: RequestInit) => Promise<Response>
+    }
+    const original = netMock.fetch
+    netMock.fetch = async () => {
+      throw Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' })
+    }
+    try {
+      await expect(http.get(`http://${lan}:9/v1/slow`)).rejects.toMatchObject({
+        isAxiosError: true,
+        code: 'TimeoutError',
+        message: 'The operation was aborted due to timeout',
+        config: { url: expect.stringContaining('/v1/slow') },
+      })
+    } finally {
+      netMock.fetch = original
+    }
+  })
 })


### PR DESCRIPTION
## 背景

排查 Pro 用户上报的 **gateway 超时问题**（UI 显示 `timeout 10000ms`），并顺带修复排查中暴露的观测盲区。

## Gateway 超时问题：分析与处置

### 线上证据链（2026-09-11，该用户 macOS 26.5.1）

| 证据 | 数据 |
|---|---|
| 症状 | UI 报 gateway `timeout 10000ms`（[gateway-supervisor.ts](apps/desktop/src/main/gateway/gateway-supervisor.ts) 健康检查超时上限） |
| Gateway 进程 | **从未退出**（无崩溃日志），是**事件循环被阻塞**——活着但响应不了健康检查 |
| 连锁故障 | `Background transcription processing tick failed`（TimeoutError）×139、`transcription:sync-private` 报错 ×52、SaaS API 超时 ×734（client=saas，ETIMEDOUT）三类错误同步爆发 |
| 恶化曲线 | 14:00-19:00 温和恶化（9-22 次/小时）→ 20:00-21:00 爆发（364 次/小时）→ 22:01 用户关闭应用 |

根因方向：代码注释已知"**ingest 扇出期间 gateway 事件循环会被同步 sqlite 写入卡住**"；转写/摘要的写入压力让阻塞逐渐加剧，10s 健康检查、转写 tick、sync-private 全部打不进去。

### 本 PR 的处置（两层）

**已修：切断恶化放大回路（commit `179592eb`）**

处理循环 tick 失败后从固定 5s 重试改为**指数退避**（5s→10s→20s→40s→60s，成功归零）。故障期间固定 5 秒重试意味着每轮都重新打 SaaS 认领 + 网关健康检查 + 同步——对已阻塞的网关持续加压，这正是"温和恶化→爆发"曲线的放大器。退避后系统退化时轮询负载降为原来的 1/12，给网关恢复留出窗口。

**铺路：让下次发生时能看到网关内部现场（commit `4c6ba85e`）**

网关子进程输出此前只进本地控制台，远端零可见，这次只能靠外围绕过证据推断根因方向。现在 stderr/error 行限频上报（30 条/分钟），下次网关阻塞时能直接看到它卡在哪个操作上。

### 根修计划（不在本 PR，建议下一专项）

gateway 的同步 sqlite 写入（ingest/转写扇出路径）需要改为异步写入/WAL/写 batching——这是 `apps/gateway` 侧的存储层改造，影响面大，需要本 PR 上线的观测数据锁定具体阻塞点后再动手。

## 顺带修复的观测问题

1. **5 万条 "[object Object]" 垃圾日志根因**：SDK 的 ElectronNet 自动埋点在 enableLogs 下把**每个 Electron 网络请求**记成 info 日志（`origin=auto.electron.net`），轮询请求 5s 一条 × 2 天刷爆远端（占该用户日志量 98%，掩盖真实错误信号）——已加入禁用清单
2. **console 捕获序列化 Error**：此前 `{"name":"TimeoutError"}`，message/stack 全丢；现为 `{name, message, stack 前 10 行}`
3. **http 超时日志不丢 url/method**：chromium 适配器网络错误包装为 AxiosError 携带 config（线上已确认 url 属性全空，无法定位是哪个调用超时）
4. **邮箱查询**：日志带 `user.email`（PR #200 已生效）、事件经 `setUser({id, email})`——后台搜索框 `user.email:xxx@yyy.com` 即可（老数据无 email；手机端需各自加 setUser）

## 验证

- `apps/desktop` typecheck 通过；17 个用例全过（新增：网关输出分级上报与限频、Error 序列化、适配器错误保留 config）
- 发版后建议实测：Pro 账号复现一次 gateway 超时 → 后台 Logs 按模块 `gateway-` 过滤看网关内部现场、tick 失败间隔应呈退避曲线（5s→10s→20s…）而非固定 5s